### PR TITLE
feat(layout): add grid sub-layouts for 3 players and sequential instance launching

### DIFF
--- a/helper/CouchPlayHelper.cpp
+++ b/helper/CouchPlayHelper.cpp
@@ -132,13 +132,10 @@ private:
     CouchPlayHelper *m_helper;
 };
 
-// Username validation: lowercase, starts with letter, 1-32 chars, letters/digits/underscore/hyphen
 static const QRegularExpression s_validUsername(QStringLiteral("^[a-z][a-z0-9_-]{0,31}$"));
 
-// Version of the helper daemon
 static const QString HELPER_VERSION = QStringLiteral("0.2.0");
 
-// PolicyKit actions
 static const QString ACTION_DEVICE_OWNER = QStringLiteral("io.github.hikaps.couchplay.change-device-owner");
 static const QString ACTION_CREATE_USER = QStringLiteral("io.github.hikaps.couchplay.create-user");
 static const QString ACTION_DELETE_USER = QStringLiteral("io.github.hikaps.couchplay.delete-user");
@@ -147,7 +144,6 @@ static const QString ACTION_WAYLAND_ACCESS = QStringLiteral("io.github.hikaps.co
 static const QString ACTION_LAUNCH_INSTANCE = QStringLiteral("io.github.hikaps.couchplay.launch-instance");
 static const QString ACTION_MANAGE_MOUNTS = QStringLiteral("io.github.hikaps.couchplay.manage-mounts");
 
-// couchplay group name for managed users
 static const QString COUCHPLAY_GROUP = QStringLiteral("couchplay");
 
 CouchPlayHelper::CouchPlayHelper(SystemOps *ops, QObject *parent)
@@ -160,7 +156,6 @@ CouchPlayHelper::CouchPlayHelper(SystemOps *ops, QObject *parent)
 
 CouchPlayHelper::~CouchPlayHelper()
 {
-    // Clean up: remove runtime access for all compositor UIDs
     for (uint uid : m_runtimeAccessSetForUid) {
         QString runtimeDir = QStringLiteral("/run/user/%1").arg(uid);
         removeRuntimeAcls(runtimeDir);
@@ -168,7 +163,6 @@ CouchPlayHelper::~CouchPlayHelper()
     }
     m_runtimeAccessSetForUid.clear();
 
-    // Clean up: unmount all shared directories
     if (!m_activeMounts.isEmpty()) {
         for (const QString &username : m_activeMounts.keys()) {
             for (const MountInfo &mount : m_activeMounts[username]) {
@@ -188,7 +182,6 @@ CouchPlayHelper::~CouchPlayHelper()
         m_activeMounts.clear();
     }
 
-    // Clean up: stop all launched transient units
     for (const QString &serviceName : m_usernameToUnitName) {
         m_stoppingUnits.insert(serviceName);
         stopServiceInstance(serviceName);
@@ -199,7 +192,6 @@ CouchPlayHelper::~CouchPlayHelper()
     qDeleteAll(m_monitors);
     m_monitors.clear();
 
-    // Clean up: reset all modified devices on shutdown
     if (!m_modifiedDevices.isEmpty()) {
         ResetAllDevices();
     }
@@ -207,21 +199,18 @@ CouchPlayHelper::~CouchPlayHelper()
 
 bool CouchPlayHelper::ChangeDeviceOwner(const QString &devicePath, uint uid)
 {
-    // Validate input
     if (!isValidDevicePath(devicePath)) {
         sendErrorReply(QDBusError::InvalidArgs, 
             QStringLiteral("Invalid device path: %1").arg(devicePath));
         return false;
     }
 
-    // Check authorization
     if (!checkAuthorization(ACTION_DEVICE_OWNER)) {
         sendErrorReply(QDBusError::AccessDenied, 
             QStringLiteral("Not authorized to change device ownership"));
         return false;
     }
 
-    // Verify user exists
     struct passwd *pw = m_ops->getpwuid(uid);
     if (!pw) {
         sendErrorReply(QDBusError::InvalidArgs,
@@ -229,7 +218,7 @@ bool CouchPlayHelper::ChangeDeviceOwner(const QString &devicePath, uint uid)
         return false;
     }
 
-    // Change ownership
+    // Set permissions to 0600 (owner read/write only) for input isolation
     if (m_ops->chown(devicePath, uid, pw->pw_gid) != 0) {
         sendErrorReply(QDBusError::Failed,
             QStringLiteral("Failed to change ownership of %1: %2")
@@ -246,7 +235,6 @@ bool CouchPlayHelper::ChangeDeviceOwner(const QString &devicePath, uint uid)
         return false;
     }
 
-    // Track this device for cleanup
     if (!m_modifiedDevices.contains(devicePath)) {
         m_modifiedDevices.append(devicePath);
     }
@@ -281,7 +269,6 @@ bool CouchPlayHelper::ResetDeviceOwner(const QString &devicePath)
         return false;
     }
 
-    // Get the 'input' group GID for proper reset
     struct group *inputGroup = m_ops->getgrnam("input");
     gid_t inputGid = inputGroup ? inputGroup->gr_gid : 0;
 
@@ -307,16 +294,14 @@ bool CouchPlayHelper::ResetDeviceOwner(const QString &devicePath)
 int CouchPlayHelper::ResetAllDevices()
 {
     int successCount = 0;
-    QStringList devices = m_modifiedDevices; // Copy since we modify during iteration
+    QStringList devices = m_modifiedDevices;
     
-    // Get the 'input' group GID for proper reset
     struct group *inputGroup = m_ops->getgrnam("input");
     gid_t inputGid = inputGroup ? inputGroup->gr_gid : 0;
 
     for (const QString &path : devices) {
-        // Direct reset without auth check for cleanup scenarios
-        // Reset to root:input with 0660 permissions
-        if (m_ops->chown(path, 0, inputGid) == 0 &&
+    // Restore to root:input with 0660 permissions
+    if (m_ops->chown(path, 0, inputGid) == 0 &&
             m_ops->chmod(path, 0660) == 0) {
             successCount++;
             m_modifiedDevices.removeAll(path);
@@ -330,7 +315,6 @@ int CouchPlayHelper::ResetAllDevices()
 
 uint CouchPlayHelper::CreateUser(const QString &username, const QString &fullName)
 {
-    // Validate username (alphanumeric, lowercase, starts with letter)
     if (!s_validUsername.match(username).hasMatch()) {
         sendErrorReply(QDBusError::InvalidArgs, 
             QStringLiteral("Invalid username format"));
@@ -343,14 +327,12 @@ uint CouchPlayHelper::CreateUser(const QString &username, const QString &fullNam
         return 0;
     }
 
-    // Check if user already exists
     if (userExists(username)) {
         sendErrorReply(QDBusError::Failed, 
             QStringLiteral("User '%1' already exists").arg(username));
         return 0;
     }
 
-    // Ensure couchplay group exists (create if needed)
     // -f flag means no error if group exists, so we don't check exit code
     runCommand(QStringLiteral("groupadd"), {QStringLiteral("-f"), COUCHPLAY_GROUP});
 
@@ -361,7 +343,6 @@ uint CouchPlayHelper::CreateUser(const QString &username, const QString &fullNam
          << QStringLiteral("-c") << fullName
          << QStringLiteral("-s") << QStringLiteral("/bin/bash");
 
-    // Add supplementary groups: input (for gamepad access) and couchplay (for management)
     args << QStringLiteral("-G") << QStringLiteral("input,") + COUCHPLAY_GROUP;
 
     args << username;
@@ -378,7 +359,6 @@ uint CouchPlayHelper::CreateUser(const QString &username, const QString &fullNam
     }
     delete process;
 
-    // Get the new user's UID
     uint uid = getUserUid(username);
     if (uid == 0) {
         sendErrorReply(QDBusError::Failed,
@@ -386,8 +366,7 @@ uint CouchPlayHelper::CreateUser(const QString &username, const QString &fullNam
         return 0;
     }
 
-    // Enable linger for the new user so their systemd user session starts at boot
-    // This is required for systemd-run transient units to access the user's D-Bus session
+    // Enable linger so systemd user session starts at boot (required for systemd-run transient units)
     QProcess *lingerProcess = m_ops->createProcess();
     m_ops->startProcess(lingerProcess, QStringLiteral("loginctl"),
         {QStringLiteral("enable-linger"), username});
@@ -459,10 +438,9 @@ bool CouchPlayHelper::IsInCouchPlayGroup(const QString &username)
     // Get the couchplay group
     struct group *grp = m_ops->getgrnam(COUCHPLAY_GROUP.toLocal8Bit().constData());
     if (!grp) {
-        return false;  // Group doesn't exist
+        return false;
     }
 
-    // Check if username is in the group's member list
     for (char **member = grp->gr_mem; *member != nullptr; ++member) {
         if (username == QString::fromLocal8Bit(*member)) {
             return true;
@@ -484,7 +462,7 @@ bool CouchPlayHelper::DeleteUser(const QString &username, bool removeHome)
         return false;
     }
 
-    // CRITICAL: Only allow deleting users in the couchplay group
+    // Only allow deleting users in the couchplay group
     if (!IsInCouchPlayGroup(username)) {
         sendErrorReply(QDBusError::AccessDenied, 
             QStringLiteral("User '%1' is not a CouchPlay user (not in couchplay group)").arg(username));
@@ -495,32 +473,24 @@ bool CouchPlayHelper::DeleteUser(const QString &username, bool removeHome)
     struct passwd *pw = m_ops->getpwnam(username.toLocal8Bit().constData());
     uid_t userUid = pw ? pw->pw_uid : 0;
 
-    // Disable linger first
-    // Don't fail if this doesn't work
+    // Don't fail if these don't work
     runCommand(QStringLiteral("loginctl"), {QStringLiteral("disable-linger"), username});
-
-    // Kill any running processes for the user
-    // Don't fail if there are no processes to kill
     runCommand(QStringLiteral("pkill"), {QStringLiteral("-u"), username});
 
     // Wait a moment for processes to terminate
     QThread::msleep(500);
 
-    // Clean up IPC resources (semaphores, shared memory, message queues) owned by the user
-    // This prevents "Permission denied" errors if a new user is created with the same name
-    // but a different UID, and tries to access stale IPC resources from the old user.
+    // Clean up IPC resources to prevent "Permission denied" errors if a new user
+    // gets the same name with a different UID and tries to access stale resources
     if (userUid > 0) {
-        // Remove semaphores owned by the user
         runCommand(QStringLiteral("/bin/bash"),
             {QStringLiteral("-c"),
              QStringLiteral("ipcs -s | awk '$3 == %1 {print $2}' | xargs -r ipcrm -s").arg(userUid)});
 
-        // Remove shared memory segments owned by the user
         runCommand(QStringLiteral("/bin/bash"),
             {QStringLiteral("-c"),
              QStringLiteral("ipcs -m | awk '$3 == %1 {print $2}' | xargs -r ipcrm -m").arg(userUid)});
 
-        // Remove message queues owned by the user
         runCommand(QStringLiteral("/bin/bash"),
             {QStringLiteral("-c"),
              QStringLiteral("ipcs -q | awk '$3 == %1 {print $2}' | xargs -r ipcrm -q").arg(userUid)});
@@ -536,11 +506,10 @@ bool CouchPlayHelper::DeleteUser(const QString &username, bool removeHome)
              QStringLiteral("-delete")});
     }
 
-    // Delete user with userdel
     QProcess *process = m_ops->createProcess();
     QStringList args;
     if (removeHome) {
-        args << QStringLiteral("-r");  // Remove home directory
+        args << QStringLiteral("-r");
     }
     args << username;
 
@@ -567,7 +536,6 @@ bool CouchPlayHelper::EnableLinger(const QString &username)
         return false;
     }
 
-    // Enable linger via loginctl
     QProcess *process = m_ops->createProcess();
     m_ops->startProcess(process, QStringLiteral("loginctl"),
         {QStringLiteral("enable-linger"), username});
@@ -587,7 +555,7 @@ bool CouchPlayHelper::EnableLinger(const QString &username)
 
 bool CouchPlayHelper::IsLingerEnabled(const QString &username)
 {
-    // Check if linger file exists in /var/lib/systemd/linger/
+    // Linger state is stored as a file in /var/lib/systemd/linger/
     QString lingerFile = QStringLiteral("/var/lib/systemd/linger/%1").arg(username);
     return m_ops->fileExists(lingerFile);
 }
@@ -600,7 +568,6 @@ bool CouchPlayHelper::SetupRuntimeAccess(uint compositorUid)
         return false;
     }
 
-    // Verify compositor user exists
     struct passwd *pw = m_ops->getpwuid(compositorUid);
     if (!pw) {
         sendErrorReply(QDBusError::InvalidArgs,
@@ -618,11 +585,10 @@ bool CouchPlayHelper::SetupRuntimeAccess(uint compositorUid)
 
     bool success = true;
 
-    // Helper lambda for setfacl — removes stale entries first to avoid
-    // "Duplicate entries" errors from leftover GIDs across reinstalls.
+    // Remove stale entries first to avoid "Duplicate entries" errors from leftover GIDs
     auto setAcl = [&](const QString &path, const QString &perm) -> bool {
         if (!m_ops->fileExists(path)) {
-            return true;  // Not an error - optional paths
+            return true;
         }
         QProcess *removeProc = m_ops->createProcess();
         m_ops->startProcess(removeProc, QStringLiteral("setfacl"),
@@ -643,14 +609,12 @@ bool CouchPlayHelper::SetupRuntimeAccess(uint compositorUid)
         return aclOk;
     };
 
-    // Runtime directory - traverse permission
     if (!setAcl(runtimeDir, QStringLiteral("x"))) {
         sendErrorReply(QDBusError::Failed, 
             QStringLiteral("Failed to set ACL on runtime directory"));
         return false;
     }
 
-    // Wayland socket
     QString waylandSocket = runtimeDir + QStringLiteral("/wayland-0");
     if (!setAcl(waylandSocket, QStringLiteral("rw"))) {
         sendErrorReply(QDBusError::Failed, 
@@ -658,18 +622,14 @@ bool CouchPlayHelper::SetupRuntimeAccess(uint compositorUid)
         return false;
     }
 
-    // X authentication files
     for (const QString &xauthFile : m_ops->entryList(runtimeDir, {QStringLiteral("xauth_*")}, QDir::Files)) {
         setAcl(runtimeDir + QStringLiteral("/") + xauthFile, QStringLiteral("r"));
     }
 
-    // PipeWire sockets
     success &= setAcl(runtimeDir + QStringLiteral("/pipewire-0"), QStringLiteral("rw"));
     success &= setAcl(runtimeDir + QStringLiteral("/pipewire-0-manager"), QStringLiteral("rw"));
 
-    // PulseAudio compatibility
-    // The pulse directory typically has mode 0700, which means the ACL mask is ---
-    // We need to set both the group ACL and update the mask for it to be effective
+    // PulseAudio: mode 0700 means ACL mask is ---, so we must set both group ACL and mask
     QString pulseDir = runtimeDir + QStringLiteral("/pulse");
     if (m_ops->fileExists(pulseDir)) {
         QProcess *proc = m_ops->createProcess();
@@ -795,12 +755,11 @@ bool CouchPlayHelper::runCommand(const QString &program, const QStringList &args
 
 bool CouchPlayHelper::isValidDevicePath(const QString &path)
 {
-    // Check for path traversal attempts
+    // Check for path traversal
     if (path.contains(QStringLiteral(".."))) {
         return false;
     }
 
-    // Must be under /dev/input/ OR /dev/hidraw*
     bool isInputDevice = path.startsWith(QStringLiteral("/dev/input/"));
     bool isHidrawDevice = path.startsWith(QStringLiteral("/dev/hidraw"));
 
@@ -808,7 +767,6 @@ bool CouchPlayHelper::isValidDevicePath(const QString &path)
         return false;
     }
 
-    // Validate hidraw path format strictly
     if (isHidrawDevice) {
         static QRegularExpression hidrawRegex(QStringLiteral("^/dev/hidraw\\d+$"));
         if (!hidrawRegex.match(path).hasMatch()) {
@@ -816,7 +774,6 @@ bool CouchPlayHelper::isValidDevicePath(const QString &path)
         }
     }
 
-    // Must be a character device
     if (!m_ops->fileExists(path)) {
         return false;
     }
@@ -826,7 +783,6 @@ bool CouchPlayHelper::isValidDevicePath(const QString &path)
         return false;
     }
 
-    // Must be a character device (input devices are char devices)
     return m_ops->isCharDevice(st.st_mode);
 }
 
@@ -965,9 +921,8 @@ qint64 CouchPlayHelper::startTransientUnit(const QString &username, uint composi
     QString compositorRuntimeDir = QStringLiteral("/run/user/%1").arg(compositorUid);
     QString userRuntimeDir = QStringLiteral("/run/user/%1").arg(userUid);
 
-    // Ensure the gaming user's runtime directory exists (requires linger to be enabled).
-    // Without this, XDG_RUNTIME_DIR points to a non-existent path and PipeWire clients
-    // as well as gamescope (lockfiles) will fail silently.
+    // Runtime directory must exist (requires linger) — without it, PipeWire
+    // and gamescope lockfiles fail silently
     if (!m_ops->fileExists(userRuntimeDir)) {
         qInfo() << "Creating missing runtime directory" << userRuntimeDir << "for" << username;
         m_ops->mkpath(userRuntimeDir);
@@ -981,18 +936,16 @@ qint64 CouchPlayHelper::startTransientUnit(const QString &username, uint composi
     systemdRunArgs << QStringLiteral("--property=Delegate=yes");
     systemdRunArgs << QStringLiteral("--property=MemoryDenyWriteExecute=false");
 
-    // Use -E flag for each environment variable (cleaner escaping than --property=Environment=)
+    // -E flag avoids escaping issues with --property=Environment=
     auto addEnv = [&](const QString &assignment) {
         systemdRunArgs << QStringLiteral("-E") << assignment;
     };
     addEnv(QStringLiteral("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%1/bus").arg(userUid));
     addEnv(QStringLiteral("WAYLAND_DISPLAY=%1/wayland-0").arg(compositorRuntimeDir));
     addEnv(QStringLiteral("XDG_RUNTIME_DIR=/run/user/%1").arg(userUid));
-    // For audio, point to the compositor user's PipeWire socket
     addEnv(QStringLiteral("PIPEWIRE_RUNTIME_DIR=%1").arg(compositorRuntimeDir));
-    // PulseAudio compatibility: only set PULSE_SERVER if the pulse socket exists.
-    // SDL tries PulseAudio first when PULSE_SERVER is set; if the socket is missing,
-    // some SDL versions fail to fall back to PipeWire native, causing silent audio.
+    // Only set PULSE_SERVER if socket exists — SDL tries PulseAudio first when set,
+    // and some versions fail to fall back to PipeWire native if socket is missing
     QString pulseSocket = compositorRuntimeDir + QStringLiteral("/pulse/native");
     if (m_ops->fileExists(pulseSocket)) {
         addEnv(QStringLiteral("PULSE_SERVER=unix:%1").arg(pulseSocket));
@@ -1010,8 +963,7 @@ qint64 CouchPlayHelper::startTransientUnit(const QString &username, uint composi
         systemdRunArgs << QStringLiteral("--property=BindPaths=%1").arg(bp);
     }
 
-    // Resolve gamescope binary path dynamically — on immutable distros (Bazzite/rpm-ostree)
-    // the location may differ from /usr/bin/gamescope.
+    // On immutable distros, gamescope may not be at /usr/bin/gamescope
     QString gamescopePath = QStringLiteral("/usr/bin/gamescope");
     if (!m_ops->fileExists(gamescopePath)) {
         QProcess *whichProc = m_ops->createProcess();
@@ -1076,7 +1028,7 @@ qint64 CouchPlayHelper::startTransientUnit(const QString &username, uint composi
         delete proc;
     }
 
-    // Wait briefly for systemd to register the unit, then poll for MainPID (max 3 attempts)
+    // Poll for MainPID (systemd needs a moment to register the unit)
     qint64 mainPid = 0;
     for (int attempt = 0; attempt < 3; ++attempt) {
         QThread::msleep(500);
@@ -1156,21 +1108,15 @@ void CouchPlayHelper::monitorUnitState(const QString &serviceName, const QString
 QString CouchPlayHelper::computeMountTarget(const QString &source, const QString &alias,
                                              const QString &userHome, const QString &compositorHome)
 {
-    // Determine where to mount the source directory in the user's home
-    
     if (source.startsWith(compositorHome) && alias.isEmpty()) {
-        // Home-relative: mount at same relative path in user's home
         QString relativePath = source.mid(compositorHome.length());
         return userHome + relativePath;
     } else if (!alias.isEmpty()) {
-        // Has alias: mount at specified location relative to user's home
         if (alias.startsWith(QLatin1Char('/'))) {
-            // Absolute alias - just append to home (remove leading slash)
             return userHome + alias;
         }
         return userHome + QStringLiteral("/") + alias;
     } else {
-        // Non-home path, no alias: mount under .couchplay/mounts/
         return userHome + QStringLiteral("/.couchplay/mounts") + source;
     }
 }
@@ -1199,7 +1145,6 @@ int CouchPlayHelper::MountSharedDirectories(const QString &username, uint compos
     int successCount = 0;
 
     for (const QString &dirSpec : directories) {
-        // Parse "source|alias" format
         QStringList parts = dirSpec.split(QLatin1Char('|'));
         if (parts.isEmpty()) {
             continue;
@@ -1208,28 +1153,23 @@ int CouchPlayHelper::MountSharedDirectories(const QString &username, uint compos
         QString source = parts.at(0);
         QString alias = parts.size() > 1 ? parts.at(1) : QString();
 
-        // Validate source path exists
         if (!m_ops->fileExists(source)) {
             qWarning() << "MountSharedDirectories: Source path does not exist:" << source;
             continue;
         }
 
-        // Validate source is a directory
         if (!m_ops->isDirectory(source)) {
             qWarning() << "MountSharedDirectories: Source is not a directory:" << source;
             continue;
         }
 
-        // Compute target path
         QString target = computeMountTarget(source, alias, userHome, compositorHome);
 
-        // Create target directory if it doesn't exist
         if (!m_ops->fileExists(target)) {
             if (!m_ops->mkpath(target)) {
                 qWarning() << "MountSharedDirectories: Failed to create target directory:" << target;
                 continue;
             }
-            // Set ownership of created directory to the target user
             uint userUid = getUserUid(username);
             struct passwd *pw = m_ops->getpwuid(userUid);
             if (pw) {
@@ -1237,7 +1177,6 @@ int CouchPlayHelper::MountSharedDirectories(const QString &username, uint compos
             }
         }
 
-        // Perform bind mount
         QProcess *mountProcess = m_ops->createProcess();
         m_ops->startProcess(mountProcess, QStringLiteral("/usr/bin/mount"),
             {QStringLiteral("--bind"), source, target});
@@ -1251,7 +1190,6 @@ int CouchPlayHelper::MountSharedDirectories(const QString &username, uint compos
         }
         delete mountProcess;
 
-        // Track the mount for cleanup
         MountInfo info;
         info.source = source;
         info.target = target;
@@ -1267,7 +1205,6 @@ int CouchPlayHelper::MountSharedDirectories(const QString &username, uint compos
 
 int CouchPlayHelper::UnmountSharedDirectories(const QString &username)
 {
-    // Validate username
     if (!s_validUsername.match(username).hasMatch()) {
         sendErrorReply(QDBusError::InvalidArgs, 
             QStringLiteral("Invalid username format"));
@@ -1281,7 +1218,7 @@ int CouchPlayHelper::UnmountSharedDirectories(const QString &username)
     }
 
     if (!m_activeMounts.contains(username)) {
-        return 0;  // No mounts to remove
+        return 0;
     }
 
     int successCount = 0;
@@ -1369,7 +1306,6 @@ bool CouchPlayHelper::CopyFileToUser(const QString &sourcePath, const QString &t
         return false;
     }
 
-    // Validate source file exists
     if (!m_ops->fileExists(sourcePath)) {
         qWarning() << "CopyFileToUser: Source file does not exist:" << sourcePath;
         sendErrorReply(QDBusError::InvalidArgs,
@@ -1377,7 +1313,6 @@ bool CouchPlayHelper::CopyFileToUser(const QString &sourcePath, const QString &t
         return false;
     }
 
-    // Get user info for ownership
     uint userUid = getUserUid(username);
     struct passwd *pw = m_ops->getpwuid(userUid);
     if (!pw) {
@@ -1387,7 +1322,6 @@ bool CouchPlayHelper::CopyFileToUser(const QString &sourcePath, const QString &t
         return false;
     }
 
-    // Create parent directories if needed
     int lastSlash = targetPath.lastIndexOf(QLatin1Char('/'));
     QString targetDir = (lastSlash >= 0) ? targetPath.left(lastSlash) : QStringLiteral(".");
 
@@ -1407,8 +1341,7 @@ bool CouchPlayHelper::CopyFileToUser(const QString &sourcePath, const QString &t
         m_ops->chown(dir, userUid, pw->pw_gid);
     }
 
-    // Copy the file
-    // Remove target first if it exists
+    // Remove target first if it exists (copyFile won't overwrite)
     if (m_ops->fileExists(targetPath)) {
         m_ops->removeFile(targetPath);
     }
@@ -1420,13 +1353,10 @@ bool CouchPlayHelper::CopyFileToUser(const QString &sourcePath, const QString &t
         return false;
     }
 
-    // Set ownership on the copied file
     if (m_ops->chown(targetPath, userUid, pw->pw_gid) != 0) {
         qWarning() << "CopyFileToUser: Failed to set ownership on" << targetPath;
-        // Don't fail - file was copied successfully
     }
 
-    // Set permissions to 0644 (owner read/write, group/other read)
     if (m_ops->chmod(targetPath, 0644) != 0) {
         qWarning() << "CopyFileToUser: Failed to set permissions on" << targetPath;
     }
@@ -1441,7 +1371,6 @@ bool CouchPlayHelper::WriteFileToUser(const QByteArray &content, const QString &
         return false;
     }
 
-    // Get user info for ownership
     uint userUid = getUserUid(username);
     struct passwd *pw = m_ops->getpwuid(userUid);
     if (!pw) {
@@ -1451,7 +1380,6 @@ bool CouchPlayHelper::WriteFileToUser(const QByteArray &content, const QString &
         return false;
     }
 
-    // Create parent directories if needed
     int lastSlash = targetPath.lastIndexOf(QLatin1Char('/'));
     QString targetDir = (lastSlash >= 0) ? targetPath.left(lastSlash) : QStringLiteral(".");
 
@@ -1471,7 +1399,6 @@ bool CouchPlayHelper::WriteFileToUser(const QByteArray &content, const QString &
         m_ops->chown(dir, userUid, pw->pw_gid);
     }
 
-    // Write the file
     if (!m_ops->writeFile(targetPath, content)) {
         qWarning() << "WriteFileToUser: Failed to write to" << targetPath;
         sendErrorReply(QDBusError::Failed,
@@ -1479,13 +1406,10 @@ bool CouchPlayHelper::WriteFileToUser(const QByteArray &content, const QString &
         return false;
     }
 
-    // Set ownership on the file
     if (m_ops->chown(targetPath, userUid, pw->pw_gid) != 0) {
         qWarning() << "WriteFileToUser: Failed to set ownership on" << targetPath;
-        // Don't fail - file was written successfully
     }
 
-    // Set permissions to 0644
     if (m_ops->chmod(targetPath, 0644) != 0) {
         qWarning() << "WriteFileToUser: Failed to set permissions on" << targetPath;
     }
@@ -1499,7 +1423,6 @@ bool CouchPlayHelper::CreateUserDirectory(const QString &path, const QString &us
         return false;
     }
 
-    // Get user info for ownership
     uint userUid = getUserUid(username);
     struct passwd *pw = m_ops->getpwuid(userUid);
     if (!pw) {
@@ -1513,7 +1436,6 @@ bool CouchPlayHelper::CreateUserDirectory(const QString &path, const QString &us
         return false;
     }
 
-    // Create directories
     if (!m_ops->mkpath(path)) {
         sendErrorReply(QDBusError::Failed,
             QStringLiteral("Failed to create directory: %1").arg(path));
@@ -1533,16 +1455,12 @@ bool CouchPlayHelper::SetDirectoryAcl(const QString &path, const QString &userna
         return false;
     }
 
-    // Check if path exists
     if (!m_ops->fileExists(path)) {
         sendErrorReply(QDBusError::InvalidArgs,
             QStringLiteral("Path does not exist: %1").arg(path));
         return false;
     }
 
-    // Build setfacl command
-    // setfacl -m u:username:rx /path (non-recursive)
-    // setfacl -R -m u:username:rx /path (recursive)
     QStringList args;
     if (recursive) {
         args << QStringLiteral("-R");
@@ -1579,16 +1497,13 @@ bool CouchPlayHelper::SetPathAclWithParents(const QString &path, const QString &
         return false;
     }
 
-    // Check if path exists
     if (!m_ops->fileExists(path)) {
         sendErrorReply(QDBusError::InvalidArgs,
             QStringLiteral("Path does not exist: %1").arg(path));
         return false;
     }
 
-    // Safe boundaries where we stop traversing upward
-    // These are directories that either already have proper permissions
-    // or we shouldn't modify
+    // Stop traversing at well-known mount points we shouldn't modify
     static const QStringList stopBoundaries = {
         QStringLiteral("/run/media"),
         QStringLiteral("/media"),
@@ -1598,23 +1513,19 @@ bool CouchPlayHelper::SetPathAclWithParents(const QString &path, const QString &
         QStringLiteral("/"),
     };
 
-    // Collect all parent directories that need ACLs
     QStringList pathsToSet;
     QString current = path;
     
-    // Normalize path (remove trailing slash)
     while (current.endsWith(QLatin1Char('/')) && current.length() > 1) {
         current.chop(1);
     }
     
-    // Add the target path first
     pathsToSet.prepend(current);
     
-    // Walk up the directory tree
     while (true) {
         int lastSlash = current.lastIndexOf(QLatin1Char('/'));
         if (lastSlash <= 0) {
-            break;  // Reached root
+            break;
         }
         
         current = current.left(lastSlash);
@@ -1622,7 +1533,6 @@ bool CouchPlayHelper::SetPathAclWithParents(const QString &path, const QString &
             current = QStringLiteral("/");
         }
         
-        // Check if we've reached a stop boundary
         bool atBoundary = false;
         for (const QString &boundary : stopBoundaries) {
             if (current == boundary || current.length() < boundary.length()) {
@@ -1635,11 +1545,9 @@ bool CouchPlayHelper::SetPathAclWithParents(const QString &path, const QString &
             break;
         }
         
-        // Add this parent to the list (prepend so we set from top down)
         pathsToSet.prepend(current);
     }
 
-    // Set ACL on each path (non-recursive, just rx for traversal)
     bool allSucceeded = true;
     for (const QString &p : pathsToSet) {
         if (!m_ops->fileExists(p)) {
@@ -1671,8 +1579,6 @@ bool CouchPlayHelper::SetPathAclWithParents(const QString &path, const QString &
         if (m_ops->processExitCode(setfacl) != 0) {
             QString errorOutput = QString::fromUtf8(m_ops->readStandardError(setfacl));
             qWarning() << "SetPathAclWithParents: setfacl failed for" << p << ":" << errorOutput;
-            // Continue anyway - some paths might not support ACLs (e.g., NTFS)
-            // but mount point does
         }
         delete setfacl;
     }
@@ -1682,7 +1588,6 @@ bool CouchPlayHelper::SetPathAclWithParents(const QString &path, const QString &
 
 QString CouchPlayHelper::GetUserSteamId(const QString &username)
 {
-    // Validate username
     if (!s_validUsername.match(username).hasMatch()) {
         sendErrorReply(QDBusError::InvalidArgs,
             QStringLiteral("Invalid username format"));

--- a/helper/SystemOps.cpp
+++ b/helper/SystemOps.cpp
@@ -16,7 +16,6 @@ RealSystemOps::RealSystemOps(QObject *parent)
 {
 }
 
-// User/group lookup operations
 struct passwd *RealSystemOps::getpwnam(const char *name)
 {
     return ::getpwnam(name);
@@ -32,7 +31,6 @@ struct group *RealSystemOps::getgrnam(const char *name)
     return ::getgrnam(name);
 }
 
-// Filesystem operations
 bool RealSystemOps::fileExists(const QString &path)
 {
     return QFile::exists(path);
@@ -69,7 +67,6 @@ bool RealSystemOps::writeFile(const QString &path, const QByteArray &content)
     return written == content.size();
 }
 
-// Device path validation
 bool RealSystemOps::statPath(const QString &path, struct stat *buf)
 {
     return stat(path.toLocal8Bit().constData(), buf) == 0;
@@ -80,7 +77,6 @@ bool RealSystemOps::isCharDevice(mode_t mode)
     return S_ISCHR(mode);
 }
 
-// Ownership and permissions
 int RealSystemOps::chown(const QString &path, uid_t owner, gid_t group)
 {
     return ::chown(path.toLocal8Bit().constData(), owner, group);
@@ -91,7 +87,6 @@ int RealSystemOps::chmod(const QString &path, mode_t mode)
     return ::chmod(path.toLocal8Bit().constData(), mode);
 }
 
-// Process operations
 QProcess *RealSystemOps::createProcess(QObject *parent)
 {
     return new QProcess(parent);
@@ -122,29 +117,22 @@ QByteArray RealSystemOps::readAllStandardOutput(QProcess *process)
     return process->readAllStandardOutput();
 }
 
-// Directory listing
 QStringList RealSystemOps::entryList(const QString &path, const QStringList &nameFilters, QDir::Filters filters)
 {
     QDir dir(path);
     return dir.entryList(nameFilters, filters);
 }
 
-// Process signaling
 bool RealSystemOps::killProcess(pid_t pid, int signal)
 {
     return ::kill(pid, signal) == 0;
 }
 
-// Authorization check
 bool RealSystemOps::checkAuthorization(const QString &action)
 {
-    // In a full implementation, this would check PolicyKit
-    // For now, we trust the D-Bus system bus ACL
-    // TODO: Implement proper PolicyKit authorization check
-
     Q_UNUSED(action)
 
-    // Check if caller is root or in appropriate group
-    // The system D-Bus policy should restrict who can call us
+    // TODO: Implement proper PolicyKit authorization check
+    // Currently trusts the D-Bus system bus ACL for access control
     return true;
 }

--- a/helper/SystemOps.h
+++ b/helper/SystemOps.h
@@ -79,12 +79,10 @@ class RealSystemOps : public QObject, public SystemOps
 public:
     explicit RealSystemOps(QObject *parent = nullptr);
 
-    // User/group lookup operations
     struct passwd *getpwnam(const char *name) override;
     struct passwd *getpwuid(uid_t uid) override;
     struct group *getgrnam(const char *name) override;
 
-    // Filesystem operations
     bool fileExists(const QString &path) override;
     bool isDirectory(const QString &path) override;
     bool mkpath(const QString &path) override;
@@ -92,15 +90,12 @@ public:
     bool copyFile(const QString &source, const QString &dest) override;
     bool writeFile(const QString &path, const QByteArray &content) override;
 
-    // Device path validation
     bool statPath(const QString &path, struct stat *buf) override;
     bool isCharDevice(mode_t mode) override;
 
-    // Ownership and permissions
     int chown(const QString &path, uid_t owner, gid_t group) override;
     int chmod(const QString &path, mode_t mode) override;
 
-    // Process operations
     QProcess *createProcess(QObject *parent = nullptr) override;
     void startProcess(QProcess *process, const QString &program, const QStringList &arguments) override;
     bool waitForFinished(QProcess *process, int msecs) override;
@@ -108,12 +103,9 @@ public:
     QByteArray readStandardError(QProcess *process) override;
     QByteArray readAllStandardOutput(QProcess *process) override;
 
-    // Directory listing
     QStringList entryList(const QString &path, const QStringList &nameFilters, QDir::Filters filters) override;
 
-    // Process signaling
     bool killProcess(pid_t pid, int signal) override;
 
-    // Authorization check
     bool checkAuthorization(const QString &action) override;
 };

--- a/src/core/GamescopeInstance.cpp
+++ b/src/core/GamescopeInstance.cpp
@@ -262,15 +262,8 @@ QStringList GamescopeInstance::buildGamescopeArgs(const QVariantMap &config)
         args << QStringLiteral("-F") << filterMode;
     }
 
-    // Window position for split-screen layouts
-    // NOTE: --position is not available in all gamescope versions
-    // For now, we skip positioning and let the window manager handle it
-    // TODO: Investigate using xdotool/wmctrl for window positioning after spawn
-    // int posX = config.value(QStringLiteral("positionX"), -1).toInt();
-    // int posY = config.value(QStringLiteral("positionY"), -1).toInt();
-    // if (posX >= 0 && posY >= 0) {
-    //     args << QStringLiteral("--position") << QStringLiteral("%1,%2").arg(posX).arg(posY);
-    // }
+    // Window positioning is handled by WindowManager via KWin scripting
+    // (gamescope does not have a --position flag)
 
     // Monitor selection (for multi-monitor setups)
     QString monitorName = config.value(QStringLiteral("monitorName")).toString();

--- a/src/core/GamescopeInstance.cpp
+++ b/src/core/GamescopeInstance.cpp
@@ -32,7 +32,6 @@ bool GamescopeInstance::start(const QVariantMap &config, int index)
     m_index = index;
     m_username = config.value(QStringLiteral("username")).toString();
 
-    // Store window geometry for UI display
     int posX = config.value(QStringLiteral("positionX"), 0).toInt();
     int posY = config.value(QStringLiteral("positionY"), 0).toInt();
     int outputW = config.value(QStringLiteral("outputWidth"), 960).toInt();
@@ -40,25 +39,16 @@ bool GamescopeInstance::start(const QVariantMap &config, int index)
     m_windowGeometry = QRect(posX, posY, outputW, outputH);
     Q_EMIT configChanged();
 
-    // Build gamescope arguments
     QStringList gamescopeArgs = buildGamescopeArgs(config);
-
-    // Build environment
     QStringList envVars = buildEnvironment(config);
 
-    // Get preset command from SessionRunner (resolved from PresetManager)
-    // Fallback to Steam Big Picture if no preset command provided
+    // Fallback to Steam Big Picture if no preset configured
     QString gameCommand = config.value(QStringLiteral("presetCommand")).toString();
-    
     if (gameCommand.isEmpty()) {
-        // Fallback to Steam Big Picture if no preset configured
         gameCommand = QStringLiteral("steam -tenfoot -steamdeck");
     }
-    
-    // All instances go through the D-Bus helper service
-    // This provides uniform handling for all users, including the compositor user
-    
-    // Use the D-Bus helper to launch the instance
+
+    // Launch via D-Bus helper for uniform handling across all users (including compositor user)
     QDBusInterface helper(
         QStringLiteral("io.github.hikaps.CouchPlayHelper"),
         QStringLiteral("/io/github/hikaps/CouchPlayHelper"),
@@ -72,7 +62,6 @@ bool GamescopeInstance::start(const QVariantMap &config, int index)
         return false;
     }
     
-    // Use the helper service to launch the instance
     // compositorUid is the UID of the user running CouchPlay (owns the Wayland socket)
     uid_t compositorUid = getuid();
     
@@ -117,7 +106,6 @@ bool GamescopeInstance::start(const QVariantMap &config, int index)
         this, SLOT(onHelperInstanceStopped(QString, qint64, QString))
     );
     
-    // Signal running immediately since helper-launched instances don't use QProcess signals
     Q_EMIT runningChanged();
     Q_EMIT started();
 
@@ -128,7 +116,6 @@ void GamescopeInstance::stop(int timeoutMs)
 {
     Q_UNUSED(timeoutMs)
 
-    // Handle helper-launched instances
     if (m_helperPid > 0) {
         setStatus(QStringLiteral("Stopping..."));
 
@@ -166,7 +153,6 @@ void GamescopeInstance::stop(int timeoutMs)
 
 void GamescopeInstance::kill()
 {
-    // Handle helper-launched instances
     if (m_helperPid > 0) {
         setStatus(QStringLiteral("Killing..."));
 
@@ -215,15 +201,12 @@ QStringList GamescopeInstance::buildGamescopeArgs(const QVariantMap &config)
 {
     QStringList args;
 
-    // Steam integration - expose Steam-specific window properties
-    // Only enable for presets that require it (e.g., Steam Big Picture mode)
+    // Steam integration - only enable for presets that require it (e.g., Steam Big Picture)
     bool steamIntegration = config.value(QStringLiteral("steamIntegration"), false).toBool();
     if (steamIntegration) {
         args << QStringLiteral("-e");
     }
 
-    // Borderless window (optional - allows positioning but removes decorations)
-    // Default is false (decorated windows for resizing)
     bool borderless = config.value(QStringLiteral("borderless"), false).toBool();
     if (borderless) {
         args << QStringLiteral("-b");
@@ -244,7 +227,6 @@ QStringList GamescopeInstance::buildGamescopeArgs(const QVariantMap &config)
     args << QStringLiteral("-W") << QString::number(outputW);
     args << QStringLiteral("-H") << QString::number(outputH);
 
-    // Refresh rate
     int refreshRate = config.value(QStringLiteral("refreshRate"), 60).toInt();
     if (refreshRate > 0) {
         args << QStringLiteral("-r") << QString::number(refreshRate);
@@ -265,7 +247,6 @@ QStringList GamescopeInstance::buildGamescopeArgs(const QVariantMap &config)
     // Window positioning is handled by WindowManager via KWin scripting
     // (gamescope does not have a --position flag)
 
-    // Monitor selection (for multi-monitor setups)
     QString monitorName = config.value(QStringLiteral("monitorName")).toString();
     if (!monitorName.isEmpty()) {
         args << QStringLiteral("--prefer-output") << monitorName;
@@ -295,11 +276,8 @@ QStringList GamescopeInstance::buildEnvironment(const QVariantMap &config)
     // Mesa threading for better performance
     envVars << QStringLiteral("mesa_glthread=true");
     
-    // Set desktop environment for XDG portal integration
-    // This enables native file dialogs in Steam and other applications
+    // Set desktop environment for XDG portal integration (native file dialogs in Steam etc.)
     envVars << QStringLiteral("XDG_CURRENT_DESKTOP=KDE");
-    
-    // Force GTK applications to use XDG portals for file dialogs
     envVars << QStringLiteral("GTK_USE_PORTAL=1");
     
     return envVars;

--- a/src/core/GamescopeInstance.h
+++ b/src/core/GamescopeInstance.h
@@ -14,14 +14,7 @@
 struct InstanceConfig;
 
 /**
- * @brief Manages a single gamescope instance running a game
- * 
- * Handles starting gamescope with appropriate arguments for:
- * - Resolution (internal and output)
- * - Window positioning for split-screen layouts
- * - Input device isolation
- * - User execution via D-Bus helper service
- * - Direct Proton/Wine game launching
+ * @brief Manages a single gamescope instance
  */
 class GamescopeInstance : public QObject
 {
@@ -39,67 +32,22 @@ public:
     explicit GamescopeInstance(QObject *parent = nullptr);
     ~GamescopeInstance() override;
 
-    /**
-     * @brief Start the gamescope instance
-     * @param config Instance configuration containing:
-     *   - username: Linux user to run as (empty = current user)
-     *   - internalWidth/Height: Game render resolution
-     *   - outputWidth/Height: Window size
-     *   - refreshRate: Target refresh rate
-     *   - scalingMode: fit, stretch, integer, etc.
-     *   - filterMode: linear, nearest, FSR, NIS
-     *   - monitor: Monitor index for multi-monitor
-     *   - positionX/Y: Window position for split-screen
-     *   - devicePaths: List of /dev/input/eventN paths for input isolation
-     *   - executablePath: Path to game executable (.exe or native binary)
-     *   - protonPath: Path to Proton installation (for Windows games)
-     *   - prefixPath: Path to Wine/Proton prefix (WINEPREFIX/STEAM_COMPAT_DATA_PATH)
-     *   - workingDirectory: Working directory for the game (optional)
-     * @param index Instance index (0 = primary, 1+ = secondary)
-     * @return true if started successfully
-     */
     Q_INVOKABLE bool start(const QVariantMap &config, int index);
 
-    /**
-     * @brief Stop the gamescope instance gracefully
-     * @param timeoutMs Timeout before force kill (default 5000ms)
-     */
     Q_INVOKABLE void stop(int timeoutMs = 5000);
-
-    /**
-     * @brief Force kill the gamescope instance
-     */
     Q_INVOKABLE void kill();
 
-    /**
-     * @brief Check if instance is running
-     */
     bool isRunning() const;
 
-    // Property getters
     int index() const { return m_index; }
     qint64 pid() const { return m_helperPid; }
-    /**
-     * @brief Get the PID of the gamescope process
-     * @return PID, or 0 if not running
-     */
     qint64 gamescopePid() const { return m_gamescopePid; }
     QString status() const { return m_status; }
     QString username() const { return m_username; }
     QRect windowGeometry() const { return m_windowGeometry; }
 
-    /**
-     * @brief Build gamescope command line arguments from config
-     * @param config Configuration map
-     * @return List of command line arguments
-     */
     static QStringList buildGamescopeArgs(const QVariantMap &config);
 
-    /**
-     * @brief Build environment variables for the instance
-     * @param config Configuration map
-     * @return Environment variable assignments as strings
-     */
     static QStringList buildEnvironment(const QVariantMap &config);
 
 Q_SIGNALS:
@@ -122,6 +70,6 @@ private:
     QString m_status;
     QString m_username;
     QRect m_windowGeometry;
-    qint64 m_helperPid = 0;        // PID from helper service
+    qint64 m_helperPid = 0;
     qint64 m_gamescopePid = 0;
 };

--- a/src/core/PresetManager.cpp
+++ b/src/core/PresetManager.cpp
@@ -87,7 +87,6 @@ void PresetManager::initBuiltinPresets()
 {
     m_builtinPresets.clear();
 
-    // Steam Big Picture preset
     LaunchPreset steam;
     steam.id = QStringLiteral("steam");
     steam.name = QStringLiteral("Steam Big Picture");
@@ -99,7 +98,6 @@ void PresetManager::initBuiltinPresets()
     steam.sharedDirectories = getDefaultSharedDirectories(QStringLiteral("steam"));
     m_builtinPresets.append(steam);
 
-    // Heroic Games preset
     LaunchPreset heroic;
     heroic.id = QStringLiteral("heroic");
     heroic.name = QStringLiteral("Heroic Games");
@@ -108,7 +106,6 @@ void PresetManager::initBuiltinPresets()
     heroic.steamIntegration = false;
     heroic.launcherId = QStringLiteral("heroic");
 
-        // Auto-detect Heroic and populate info
         if (m_heroicConfigManager && m_heroicConfigManager->isHeroicDetected()) {
             heroic.command = m_heroicConfigManager->heroicCommand();
             heroic.launcherInfo.configPath = m_heroicConfigManager->configPath();
@@ -126,7 +123,6 @@ void PresetManager::initBuiltinPresets()
         heroic.sharedDirectories = getDefaultSharedDirectories(QStringLiteral("heroic"));
         m_builtinPresets.append(heroic);
 
-    // Lutris preset
     LaunchPreset lutris;
     lutris.id = QStringLiteral("lutris");
     lutris.name = QStringLiteral("Lutris");
@@ -199,7 +195,6 @@ LaunchPreset PresetManager::getPreset(const QString &id) const
             return preset;
         }
     }
-    // Return default (Steam) if not found
     if (!m_builtinPresets.isEmpty()) {
         return m_builtinPresets.first();
     }
@@ -289,7 +284,6 @@ QString PresetManager::addPresetFromDesktopFile(const QString &desktopFilePath)
         return QString();
     }
 
-    // Check if already exists
     for (const LaunchPreset &existing : m_customPresets) {
         if (existing.desktopFilePath == desktopFilePath) {
             return existing.id;
@@ -352,19 +346,16 @@ void PresetManager::scanApplications()
 {
     m_availableApplications.clear();
 
-    // Standard .desktop file locations
     QStringList searchPaths = {
         QStringLiteral("/usr/share/applications"),
         QStringLiteral("/usr/local/share/applications"),
         QDir::homePath() + QStringLiteral("/.local/share/applications"),
-        // Flatpak
         QDir::homePath() + QStringLiteral("/.local/share/flatpak/exports/share/applications"),
         QStringLiteral("/var/lib/flatpak/exports/share/applications"),
-        // Snap
         QStringLiteral("/var/lib/snapd/desktop/applications")
     };
 
-    QSet<QString> seenNames;  // Avoid duplicates by name
+    QSet<QString> seenNames;
 
     for (const QString &searchPath : searchPaths) {
         QDir dir(searchPath);
@@ -377,12 +368,10 @@ void PresetManager::scanApplications()
             QString filePath = dir.absoluteFilePath(fileName);
             LaunchPreset app = parseDesktopFile(filePath);
 
-            // Skip invalid or already seen
             if (app.name.isEmpty() || seenNames.contains(app.name)) {
                 continue;
             }
 
-            // Skip if already added as a custom preset
             bool alreadyAdded = false;
             for (const LaunchPreset &custom : m_customPresets) {
                 if (custom.desktopFilePath == filePath) {
@@ -399,7 +388,6 @@ void PresetManager::scanApplications()
         }
     }
 
-    // Sort by name
     std::sort(m_availableApplications.begin(), m_availableApplications.end(),
               [](const LaunchPreset &a, const LaunchPreset &b) {
                   return a.name.toLower() < b.name.toLower();
@@ -426,19 +414,16 @@ LaunchPreset PresetManager::parseDesktopFile(const QString &filePath) const
     QSettings desktop(filePath, QSettings::IniFormat);
     desktop.beginGroup(QStringLiteral("Desktop Entry"));
 
-    // Check if it's an application
     QString type = desktop.value(QStringLiteral("Type")).toString();
     if (type != QStringLiteral("Application")) {
         return preset;
     }
 
-    // Skip hidden entries
     if (desktop.value(QStringLiteral("Hidden"), false).toBool() ||
         desktop.value(QStringLiteral("NoDisplay"), false).toBool()) {
         return preset;
     }
 
-    // Extract fields
     preset.name = desktop.value(QStringLiteral("Name")).toString();
     preset.command = cleanExecCommand(desktop.value(QStringLiteral("Exec")).toString());
     preset.workingDirectory = desktop.value(QStringLiteral("Path")).toString();
@@ -471,7 +456,6 @@ QString PresetManager::cleanExecCommand(const QString &exec)
         cleaned.remove(code);
     }
 
-    // Clean up any double spaces and trim
     cleaned = cleaned.simplified();
 
     return cleaned;

--- a/src/core/PresetManager.h
+++ b/src/core/PresetManager.h
@@ -15,9 +15,6 @@
 
 /**
  * LauncherInfo - Launcher-specific configuration and paths
- * 
- * Associates a launcher with its config paths, game directories,
- * and capabilities (ACL requirements, shortcut sync support).
  */
 struct LauncherInfo {
     Q_GADGET
@@ -46,13 +43,6 @@ Q_DECLARE_METATYPE(LauncherInfo)
 
 /**
  * @brief A launch preset defining how to start a game/application
- * 
- * Presets can be builtin (Steam, Heroic, Lutris) or custom (from .desktop files
- * or user-defined). Each preset specifies the command to run, optional
- * working directory, and whether Steam integration (-e flag) is enabled.
- * 
- * Launcher-aware presets include a launcherId and LauncherInfo with associated
- * config paths and directories that need ACL setup.
  */
 struct LaunchPreset {
     Q_GADGET
@@ -142,58 +132,41 @@ public:
 
     /**
      * @brief Get a preset by ID
-     * @param id Preset ID
-     * @return The preset, or an empty preset if not found
      */
     Q_INVOKABLE LaunchPreset getPreset(const QString &id) const;
 
     /**
      * @brief Get the command for a preset
-     * @param id Preset ID
-     * @return The command string, or empty if not found
      */
     Q_INVOKABLE QString getCommand(const QString &id) const;
 
     /**
      * @brief Get the working directory for a preset
-     * @param id Preset ID
-     * @return The working directory, or empty if not specified
      */
     Q_INVOKABLE QString getWorkingDirectory(const QString &id) const;
 
     /**
      * @brief Check if a preset has Steam integration enabled
-     * @param id Preset ID
-     * @return true if Steam integration is enabled
      */
     Q_INVOKABLE bool getSteamIntegration(const QString &id) const;
 
     /**
      * @brief Get launcher ID for a preset
-     * @param id Preset ID
-     * @return Launcher ID ("steam", "heroic", "lutris", "custom", or empty)
      */
     Q_INVOKABLE QString getLauncherId(const QString &id) const;
 
     /**
      * @brief Get game directories for a launcher preset (for ACL setup)
-     * @param id Preset ID
-     * @return List of directories that need ACLs
      */
     Q_INVOKABLE QStringList getGameDirectories(const QString &id) const;
 
     /**
      * @brief Get shared directories for a preset
-     * @param id Preset ID
-     * @return List of absolute paths to shared directories
      */
     Q_INVOKABLE QStringList getSharedDirectories(const QString &id) const;
 
     /**
      * @brief Set shared directories for a preset
-     * @param id Preset ID
-     * @param directories List of absolute paths
-     * @return true if updated successfully
      */
     Q_INVOKABLE bool setSharedDirectories(const QString &id, const QStringList &directories);
 

--- a/src/core/SessionManager.cpp
+++ b/src/core/SessionManager.cpp
@@ -12,24 +12,18 @@
 SessionManager::SessionManager(QObject *parent)
     : QObject(parent)
 {
-
-    // Ensure profiles directory exists
     QDir().mkpath(profilesDir());
-
-    // Start with a new session
     newSession();
-
-    // Load existing profiles
     refreshProfiles();
 }
-
-SessionManager::~SessionManager() = default;
 
 QString SessionManager::profilesDir() const
 {
     return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) 
            + QStringLiteral("/profiles");
 }
+
+SessionManager::~SessionManager() = default;
 
 QString SessionManager::profilePath(const QString &name) const
 {
@@ -42,13 +36,10 @@ void SessionManager::newSession()
     m_currentProfile.name = QString();
     m_currentProfile.layout = QStringLiteral("horizontal");
 
-    // Default: 2 instances with no user assignment
-    // Users must be explicitly selected for all instances
     m_currentProfile.instances.clear();
     for (int i = 0; i < 2; ++i) {
         InstanceConfig config;
         config.monitor = 0;
-        // No default user assignment - user must select explicitly
         m_currentProfile.instances.append(config);
     }
 
@@ -102,7 +93,6 @@ bool SessionManager::saveProfile(const QString &name)
     general.writeEntry("gridSubLayout", m_currentProfile.gridSubLayout);
     general.writeEntry("instanceCount", m_currentProfile.instances.size());
 
-    // Instance sections
     for (int i = 0; i < m_currentProfile.instances.size(); ++i) {
         const InstanceConfig &inst = m_currentProfile.instances[i];
         KConfigGroup instGroup = config.group(QStringLiteral("Instance%1").arg(i));
@@ -125,14 +115,12 @@ bool SessionManager::saveProfile(const QString &name)
         instGroup.writeEntry("overridePatterns", inst.overridePatterns);
         instGroup.writeEntry("borderless", inst.borderless);
 
-        // Convert devices to string list (legacy - for backwards compatibility)
+        // Convert devices to string list for backwards compatibility
         QStringList deviceStrings;
         for (int dev : inst.devices) {
             deviceStrings << QString::number(dev);
         }
         instGroup.writeEntry("devices", deviceStrings);
-        
-        // Save stable device IDs (primary - survives hotplug/reboot)
         instGroup.writeEntry("deviceStableIds", inst.deviceStableIds);
         instGroup.writeEntry("deviceStableIdNames", inst.deviceStableIdNames);
     }
@@ -159,7 +147,6 @@ bool SessionManager::loadProfile(const QString &name)
 
     KConfig config(path);
 
-    // Read general section
     KConfigGroup general = config.group(QStringLiteral("General"));
     m_currentProfile.name = name;
     m_currentProfile.filePath = path;
@@ -167,7 +154,6 @@ bool SessionManager::loadProfile(const QString &name)
     m_currentProfile.gridSubLayout = general.readEntry("gridSubLayout", QString());
     int instanceCount = general.readEntry("instanceCount", 2);
 
-    // Read instances
     m_currentProfile.instances.clear();
     for (int i = 0; i < instanceCount; ++i) {
         KConfigGroup instGroup = config.group(QStringLiteral("Instance%1").arg(i));
@@ -190,7 +176,6 @@ bool SessionManager::loadProfile(const QString &name)
             instGroup.readEntry("overlayGamePath", QString()));
         inst.overrideFiles = instGroup.readEntry("overrideFiles", QStringList());
 
-        // Read overridePatterns (may not exist in old profiles)
         inst.overridePatterns = instGroup.readEntry("overridePatterns",
             instGroup.readEntry("overlayPatterns", QStringList()));
 
@@ -200,15 +185,11 @@ bool SessionManager::loadProfile(const QString &name)
             qDebug() << "Migrated overrideFiles to overridePatterns for instance" << i;
         }
 
-        // Read borderless setting (may not exist in old profiles)
         inst.borderless = instGroup.readEntry("borderless", false);
 
-        // Read stable device IDs (primary - survives hotplug/reboot)
         inst.deviceStableIds = instGroup.readEntry("deviceStableIds", QStringList());
         inst.deviceStableIdNames = instGroup.readEntry("deviceStableIdNames", QStringList());
-        
-        // Read legacy device event numbers (for backwards compatibility)
-        // These are only used if no stableIds are present, or for migration
+
         QStringList deviceStrings = instGroup.readEntry("devices", QStringList());
         for (const QString &devStr : deviceStrings) {
             inst.devices << devStr.toInt();
@@ -222,7 +203,6 @@ bool SessionManager::loadProfile(const QString &name)
     Q_EMIT instanceCountChanged();
     Q_EMIT instancesChanged();
 
-    // Build map of stable device IDs and names for each instance and emit signal
     QVariantMap deviceInfoByInstance;
     for (int i = 0; i < m_currentProfile.instances.size(); ++i) {
         const QStringList &stableIds = m_currentProfile.instances[i].deviceStableIds;
@@ -255,7 +235,6 @@ bool SessionManager::deleteProfile(const QString &name)
         return false;
     }
 
-    // Clear current profile name if we just deleted the current profile
     if (m_currentProfile.name == name) {
         m_currentProfile.name = QString();
         m_currentProfile.filePath = QString();
@@ -288,11 +267,11 @@ void SessionManager::setCurrentGridSubLayout(const QString &subLayout)
 
 void SessionManager::setInstanceCount(int count)
 {
-    if (count < 2) count = 2; // Minimum 2 for split-screen
-    if (count > 4) count = 4; // Max 4 for now
+    if (count < 2) count = 2;
+    if (count > 4) count = 4;
 
     if (m_currentProfile.instances.size() == count) {
-        return; // No change
+        return;
     }
 
     while (m_currentProfile.instances.size() < count) {
@@ -339,13 +318,13 @@ QVariantMap SessionManager::getInstanceConfig(int index) const
         deviceList << dev;
     }
     map[QStringLiteral("devices")] = deviceList;
-    
+
     QVariantList stableIdList;
     for (const QString &id : inst.deviceStableIds) {
         stableIdList << id;
     }
     map[QStringLiteral("deviceStableIds")] = stableIdList;
-    
+
     QVariantList stableIdNameList;
     for (const QString &name : inst.deviceStableIdNames) {
         stableIdNameList << name;
@@ -395,8 +374,7 @@ void SessionManager::setInstanceConfig(int index, const QVariantMap &config)
         inst.borderless = config[QStringLiteral("borderless")].toBool();
 
     Q_EMIT instancesChanged();
-    
-    // Auto-save if a profile is loaded
+
     if (!m_currentProfile.name.isEmpty()) {
         saveProfile(m_currentProfile.name);
     }
@@ -407,7 +385,6 @@ void SessionManager::setInstanceUser(int index, const QString &username)
     if (index >= 0 && index < m_currentProfile.instances.size()) {
         m_currentProfile.instances[index].username = username;
         Q_EMIT instancesChanged();
-        
         if (!m_currentProfile.name.isEmpty()) {
             saveProfile(m_currentProfile.name);
         }
@@ -419,7 +396,6 @@ void SessionManager::setInstanceMonitor(int index, int monitor)
     if (index >= 0 && index < m_currentProfile.instances.size()) {
         m_currentProfile.instances[index].monitor = monitor;
         Q_EMIT instancesChanged();
-        
         if (!m_currentProfile.name.isEmpty()) {
             saveProfile(m_currentProfile.name);
         }
@@ -435,7 +411,6 @@ void SessionManager::setInstanceResolution(int index, int internalW, int interna
         inst.outputWidth = outputW;
         inst.outputHeight = outputH;
         Q_EMIT instancesChanged();
-        
         if (!m_currentProfile.name.isEmpty()) {
             saveProfile(m_currentProfile.name);
         }
@@ -569,8 +544,6 @@ void SessionManager::recalculateOutputResolutions(int screenWidth, int screenHei
             inst.outputHeight = screenHeight;
         }
 
-        // Also set internal resolution to match output by default
-        // This avoids unnecessary scaling and gives best performance
         inst.internalWidth = inst.outputWidth;
         inst.internalHeight = inst.outputHeight;
     }

--- a/src/core/SessionManager.cpp
+++ b/src/core/SessionManager.cpp
@@ -3,6 +3,7 @@
 
 #include "SessionManager.h"
 #include "Logging.h"
+#include "SessionRunner.h"
 
 #include <QDir>
 #include <QStandardPaths>
@@ -98,6 +99,7 @@ bool SessionManager::saveProfile(const QString &name)
     KConfigGroup general = config.group(QStringLiteral("General"));
     general.writeEntry("name", name);
     general.writeEntry("layout", m_currentProfile.layout);
+    general.writeEntry("gridSubLayout", m_currentProfile.gridSubLayout);
     general.writeEntry("instanceCount", m_currentProfile.instances.size());
 
     // Instance sections
@@ -162,6 +164,7 @@ bool SessionManager::loadProfile(const QString &name)
     m_currentProfile.name = name;
     m_currentProfile.filePath = path;
     m_currentProfile.layout = general.readEntry("layout", QStringLiteral("horizontal"));
+    m_currentProfile.gridSubLayout = general.readEntry("gridSubLayout", QString());
     int instanceCount = general.readEntry("instanceCount", 2);
 
     // Read instances
@@ -267,7 +270,19 @@ void SessionManager::setCurrentLayout(const QString &layout)
 {
     if (m_currentProfile.layout != layout) {
         m_currentProfile.layout = layout;
+        if (layout != QStringLiteral("grid")) {
+            m_currentProfile.gridSubLayout.clear();
+            Q_EMIT currentGridSubLayoutChanged();
+        }
         Q_EMIT currentLayoutChanged();
+    }
+}
+
+void SessionManager::setCurrentGridSubLayout(const QString &subLayout)
+{
+    if (m_currentProfile.gridSubLayout != subLayout) {
+        m_currentProfile.gridSubLayout = subLayout;
+        Q_EMIT currentGridSubLayoutChanged();
     }
 }
 
@@ -541,10 +556,13 @@ void SessionManager::recalculateOutputResolutions(int screenWidth, int screenHei
             inst.outputWidth = screenWidth;
             inst.outputHeight = screenHeight / count;
         } else if (layout == QStringLiteral("grid")) {
-            int cols = (count <= 2) ? count : 2;
-            int rows = (count + cols - 1) / cols;
-            inst.outputWidth = screenWidth / cols;
-            inst.outputHeight = screenHeight / rows;
+            QList<QRect> layouts = SessionRunner::calculateLayout(
+                layout, count, QRect(0, 0, screenWidth, screenHeight),
+                m_currentProfile.gridSubLayout);
+            if (i < layouts.size()) {
+                inst.outputWidth = layouts[i].width();
+                inst.outputHeight = layouts[i].height();
+            }
         } else {
             // multi-monitor or unknown: use full resolution
             inst.outputWidth = screenWidth;

--- a/src/core/SessionManager.h
+++ b/src/core/SessionManager.h
@@ -40,7 +40,6 @@ struct InstanceConfig {
     Q_PROPERTY(QStringList overridePatterns MEMBER overridePatterns)
     Q_PROPERTY(bool borderless MEMBER borderless)
 
-
 public:
     QString username;
     int monitor = 0;

--- a/src/core/SessionManager.h
+++ b/src/core/SessionManager.h
@@ -73,11 +73,13 @@ struct SessionProfile {
     Q_GADGET
     Q_PROPERTY(QString name MEMBER name)
     Q_PROPERTY(QString layout MEMBER layout)
+    Q_PROPERTY(QString gridSubLayout MEMBER gridSubLayout)
     Q_PROPERTY(QString filePath MEMBER filePath)
 
 public:
     QString name;
-    QString layout = QStringLiteral("horizontal"); // horizontal, vertical, multi-monitor
+    QString layout = QStringLiteral("horizontal"); // horizontal, vertical, multi-monitor, grid
+    QString gridSubLayout; // "horizontal" (3×1) or "grid-2x2" (2×2 with gap) — only used when layout is "grid"
     QString filePath;
     QList<InstanceConfig> instances;
 };
@@ -93,6 +95,7 @@ class SessionManager : public QObject
     QML_ELEMENT
     Q_PROPERTY(QString currentProfileName READ currentProfileName NOTIFY currentProfileChanged)
     Q_PROPERTY(QString currentLayout READ currentLayout WRITE setCurrentLayout NOTIFY currentLayoutChanged)
+    Q_PROPERTY(QString currentGridSubLayout READ currentGridSubLayout WRITE setCurrentGridSubLayout NOTIFY currentGridSubLayoutChanged)
     Q_PROPERTY(int instanceCount READ instanceCount WRITE setInstanceCount NOTIFY instanceCountChanged)
     Q_PROPERTY(QVariantList savedProfiles READ savedProfilesAsVariant NOTIFY savedProfilesChanged)
     Q_PROPERTY(QVariantList instances READ instancesAsVariant NOTIFY instancesChanged)
@@ -139,6 +142,8 @@ public:
     QString currentProfileName() const { return m_currentProfile.name; }
     QString currentLayout() const { return m_currentProfile.layout; }
     void setCurrentLayout(const QString &layout);
+    QString currentGridSubLayout() const { return m_currentProfile.gridSubLayout; }
+    void setCurrentGridSubLayout(const QString &subLayout);
     int instanceCount() const { return m_currentProfile.instances.size(); }
     void setInstanceCount(int count);
 
@@ -151,6 +156,7 @@ public:
 Q_SIGNALS:
     void currentProfileChanged();
     void currentLayoutChanged();
+    void currentGridSubLayoutChanged();
     void instanceCountChanged();
     void savedProfilesChanged();
     void instancesChanged();

--- a/src/core/SessionRunner.cpp
+++ b/src/core/SessionRunner.cpp
@@ -29,25 +29,22 @@
 #include <grp.h>
 #include <unistd.h>
 
-// Name of the couchplay group for managed users
 static const QString COUCHPLAY_GROUP = QStringLiteral("couchplay");
 
-// Helper function to check if a user is in the couchplay group
 static bool isUserInCouchPlayGroup(const QString &username)
 {
     struct group *grp = getgrnam(COUCHPLAY_GROUP.toLocal8Bit().constData());
     if (!grp) {
-        return false;  // Group doesn't exist
+        return false;
     }
 
-    // Check if username is in the group's member list
     for (char **member = grp->gr_mem; *member != nullptr; ++member) {
         if (username == QString::fromLocal8Bit(*member)) {
             return true;
         }
     }
 
-    // Also check if couchplay is the user's primary group
+    // Primary group check: getgrnam(3) only returns supplementary members in gr_mem
     struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
     if (pw && pw->pw_gid == grp->gr_gid) {
         return true;
@@ -61,15 +58,12 @@ SessionRunner::SessionRunner(QObject *parent)
     , m_windowManager(new WindowManager(this))
 {
     setStatus(QStringLiteral("Ready"));
-    
-    // Set up global shortcut for stopping session
     setupGlobalShortcut();
     
     m_virtualDeviceWatcher = new VirtualDeviceWatcher(this);
     connect(m_virtualDeviceWatcher, &VirtualDeviceWatcher::virtualDeviceAppeared,
             this, &SessionRunner::onVirtualDeviceAppeared);
     
-    // Connect to window positioning signals
     connect(m_windowManager, &WindowManager::gamescopeWindowPositioned,
             this, &SessionRunner::onWindowPositioned);
     connect(m_windowManager, &WindowManager::positioningTimedOut,
@@ -108,7 +102,6 @@ void SessionRunner::setDeviceManager(DeviceManager *manager)
         
         m_deviceManager = manager;
         
-        // Connect to new manager for device reconnection handling
         if (m_deviceManager) {
             connect(m_deviceManager, &DeviceManager::deviceReconnected,
                    this, &SessionRunner::onDeviceReconnected);
@@ -172,10 +165,8 @@ bool SessionRunner::start()
 
     setStatus(QStringLiteral("Starting session..."));
 
-    // Clean up any previous instances
     cleanupInstances();
 
-    // Get session configuration
     const SessionProfile &profile = m_sessionManager->currentProfile();
     int instanceCount = profile.instances.size();
 
@@ -185,7 +176,7 @@ bool SessionRunner::start()
         return false;
     }
 
-    // Check for duplicate users - Steam can't run multiple instances under same user
+    // Steam can't run multiple instances under the same user
     QSet<QString> usedUsers;
     for (int i = 0; i < instanceCount; ++i) {
         const QString &username = profile.instances[i].username;
@@ -199,23 +190,18 @@ bool SessionRunner::start()
         }
     }
 
-    // Validate that all users either are the compositor user or are in the couchplay group
-    // This ensures only CouchPlay-managed users can be assigned to sessions
     struct passwd *compositorPw = getpwuid(getuid());
     QString compositorUser = compositorPw ? QString::fromLocal8Bit(compositorPw->pw_name) : QString();
     
     for (int i = 0; i < instanceCount; ++i) {
         const QString &username = profile.instances[i].username;
         if (username.isEmpty()) {
-            continue;  // No username assigned, will use default behavior
-        }
-        
-        // Compositor user is always allowed (they own the display)
-        if (username == compositorUser) {
             continue;
         }
         
-        // Other users must be in the couchplay group
+        if (username == compositorUser) {
+            continue;
+        }
         if (!isUserInCouchPlayGroup(username)) {
             Q_EMIT errorOccurred(QStringLiteral("User '%1' is not a CouchPlay managed user. Please create the user via CouchPlay or add them to the 'couchplay' group.").arg(username));
             setStatus(QStringLiteral("Error"));
@@ -227,36 +213,29 @@ bool SessionRunner::start()
     QRect screenGeometry = getScreenGeometry();
     m_layouts = calculateLayout(profile.layout, instanceCount, screenGeometry, profile.gridSubLayout);
 
-    // Set up device ownership (requires polkit helper)
     if (!setupDeviceOwnership()) {
         qWarning() << "Failed to set up device ownership - continuing anyway";
     }
 
-    // Set up shared directory mounts (requires polkit helper)
     if (!setupSharedDirectories()) {
         qWarning() << "Failed to set up shared directories - continuing anyway";
     }
 
-    // Build bind paths for per-instance config overrides
     buildBindPaths();
 
-    // Set up launcher access (ACLs, shortcut sync)
     if (!setupLauncherAccess()) {
         qWarning() << "Failed to set up launcher access - continuing anyway";
     }
 
-    // Build pending configs for sequential launching (fixes race condition with window positioning)
+    // Sequential launch: fixes race condition with window positioning
     m_pendingInstanceConfigs.clear();
     for (int i = 0; i < instanceCount; ++i) {
         const InstanceConfig &instConfig = profile.instances[i];
 
-        // Build config map for the instance
         QVariantMap config;
         config[QStringLiteral("username")] = instConfig.username;
         config[QStringLiteral("monitor")] = instConfig.monitor;
         
-        // Derive resolution from layout - internal resolution matches output resolution
-        // This ensures games render at the correct size for their window
         config[QStringLiteral("internalWidth")] = m_layouts[i].width();
         config[QStringLiteral("internalHeight")] = m_layouts[i].height();
         config[QStringLiteral("outputWidth")] = m_layouts[i].width();
@@ -270,7 +249,6 @@ bool SessionRunner::start()
         config[QStringLiteral("steamAppId")] = instConfig.steamAppId;
         config[QStringLiteral("borderless")] = m_borderlessWindows;
 
-        // Look up preset and add resolved command/settings
         if (m_presetManager) {
             QString presetId = instConfig.presetId;
             if (presetId.isEmpty()) {
@@ -281,13 +259,11 @@ bool SessionRunner::start()
             config[QStringLiteral("presetWorkingDirectory")] = m_presetManager->getWorkingDirectory(presetId);
             config[QStringLiteral("steamIntegration")] = m_presetManager->getSteamIntegration(presetId);
         } else {
-            // Fallback if no PresetManager
             config[QStringLiteral("presetId")] = QStringLiteral("steam");
             config[QStringLiteral("presetCommand")] = QStringLiteral("steam -tenfoot -steamdeck");
             config[QStringLiteral("steamIntegration")] = true;
         }
 
-        // Get device paths for this instance
         if (m_deviceManager) {
             QStringList devicePaths = m_deviceManager->getDevicePathsForInstance(i);
             QVariantList pathList;
@@ -329,7 +305,6 @@ void SessionRunner::stop()
 
     m_virtualDeviceWatcher->stopWatching();
 
-    // Collect override staging dirs before cleaning up instances
     QStringList overridePaths;
     if (m_sessionManager) {
         const auto &profile = m_sessionManager->currentProfile();
@@ -351,22 +326,16 @@ void SessionRunner::stop()
         }
     }
 
-    // Stop all instances
     for (auto *instance : m_instances) {
         if (instance->isRunning()) {
             instance->stop();
         }
     }
 
-    // Restore device ownership
     restoreDeviceOwnership();
-
-    // Teardown shared directory mounts
     teardownSharedDirectories();
 
     cleanupInstances();
-
-    // Clean up override staging directories
     cleanupOverrideDirs(overridePaths);
 
     setStatus(QStringLiteral("Stopped"));
@@ -427,9 +396,7 @@ QVariantList SessionRunner::instancesAsVariant() const
 
 void SessionRunner::startNextInstance()
 {
-    // Check if all instances have been started
     if (m_nextInstanceToStart >= m_pendingInstanceConfigs.size()) {
-        // All instances started - session is now fully running
         setStatus(QStringLiteral("Session running"));
         Q_EMIT runningChanged();
         Q_EMIT instancesChanged();
@@ -440,7 +407,6 @@ void SessionRunner::startNextInstance()
     int index = m_nextInstanceToStart;
     const QVariantMap &config = m_pendingInstanceConfigs[index];
 
-    // Create instance
     auto *instance = new GamescopeInstance(this);
     connect(instance, &GamescopeInstance::started, this, &SessionRunner::onInstanceStarted);
     connect(instance, &GamescopeInstance::stopped, this, &SessionRunner::onInstanceStopped);
@@ -448,7 +414,6 @@ void SessionRunner::startNextInstance()
 
     m_instances.append(instance);
 
-    // Start the instance
     if (!instance->start(config, index)) {
         qWarning() << "Failed to start instance" << index;
     }
@@ -458,12 +423,11 @@ void SessionRunner::startNextInstance()
         ++m_nextInstanceToStart;
         startNextInstance();
     }
-    // Otherwise, wait for onWindowPositioned to trigger the next start
+    // Otherwise wait for onWindowPositioned to trigger the next start
 }
 
 void SessionRunner::cleanupInstances()
 {
-    // Cancel any pending window positioning requests
     if (m_windowManager) {
         m_windowManager->cancelAllRequests();
     }
@@ -472,9 +436,8 @@ void SessionRunner::cleanupInstances()
         instance->deleteLater();
     }
     m_instances.clear();
-    m_positionedWindowIds.clear(); // Clear tracked window IDs for next session
+    m_positionedWindowIds.clear();
     
-    // Clear sequential launching state
     m_pendingInstanceConfigs.clear();
     m_layouts.clear();
     m_nextInstanceToStart = 0;
@@ -497,7 +460,7 @@ void SessionRunner::cleanupOverrideDirs(const QStringList &overridePaths)
 bool SessionRunner::setupDeviceOwnership()
 {
     if (!m_deviceManager || !m_helperClient) {
-        return true; // No helper, skip ownership setup
+        return true;
     }
 
     if (!m_helperClient->isAvailable()) {
@@ -505,10 +468,8 @@ bool SessionRunner::setupDeviceOwnership()
         return true;
     }
 
-    // Clear previous ownership tracking
     m_ownedDevicePaths.clear();
 
-    // For each instance, get its assigned devices and set ownership
     if (!m_sessionManager) {
         return true;
     }
@@ -522,7 +483,6 @@ bool SessionRunner::setupDeviceOwnership()
             continue;
         }
         
-        // Get UID for this user
         struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
         if (!pw) {
             qWarning() << "SessionRunner: User" << username << "not found, skipping device ownership for instance" << i;
@@ -530,7 +490,6 @@ bool SessionRunner::setupDeviceOwnership()
         }
         int uid = static_cast<int>(pw->pw_uid);
         
-        // Get device paths assigned to this instance
         QStringList devicePaths = m_deviceManager->getDevicePathsForInstance(i);
         
         for (const QString &path : devicePaths) {
@@ -572,7 +531,6 @@ void SessionRunner::restoreDeviceOwnership()
         return;
     }
 
-    // Use restoreAllDevices() which resets all modified devices tracked by the helper
     m_helperClient->restoreAllDevices();
     
     m_ownedDevicePaths.clear();
@@ -637,7 +595,6 @@ void SessionRunner::teardownSharedDirectories()
         return;
     }
 
-    // Unmount all shared directories for all users
     m_helperClient->unmountAllSharedDirectories();
 }
 
@@ -672,7 +629,6 @@ bool SessionRunner::buildBindPaths()
             continue;
         }
 
-        // Derive gameId from gamePath
         QString gameId = instConfig.steamAppId;
         if (gameId.isEmpty()) {
             gameId = QString::fromLatin1(QCryptographicHash::hash(
@@ -688,7 +644,7 @@ bool SessionRunner::buildBindPaths()
         }
         QString overridesRoot = getOverridesRootPath(presetId, gameId);
 
-        // Build bind path entries: "<stagingDir>/<relativeFile>:<gamePath>/<relativeFile>"
+        // Bind format: "<stagingDir>/<relativeFile>:<gamePath>/<relativeFile>"
         QStringList bindPaths;
         for (const QString &relativePath : matchedFiles) {
             QString bindEntry = overridesRoot + relativePath
@@ -740,19 +696,16 @@ bool SessionRunner::setupLauncherAccess()
             }
         }
 
-        // Handle Heroic Shortcut Sync
         if (preset.launcherId == QStringLiteral("heroic")) {
              if (m_heroicConfigManager && m_heroicConfigManager->isHeroicDetected()) {
-                 // Sync config (library) unconditionally
-                 qCDebug(couchplaySteam) << "Syncing Heroic config for user" << username;
-                 if (!m_heroicConfigManager->syncConfigToUser(username)) {
+                  qCDebug(couchplaySteam) << "Syncing Heroic config for user" << username;
+                  if (!m_heroicConfigManager->syncConfigToUser(username)) {
                      qCWarning(couchplaySteam) << "Failed to sync Heroic config to" << username;
                      allSucceeded = false;
                  }
                  
-                 // Only sync shortcuts if enabled
-                 if (m_heroicConfigManager->syncShortcutsEnabled()) {
-                     qCDebug(couchplaySteam) << "Syncing Heroic shortcuts for user" << username;
+                  if (m_heroicConfigManager->syncShortcutsEnabled()) {
+                      qCDebug(couchplaySteam) << "Syncing Heroic shortcuts for user" << username;
                      if (!m_heroicConfigManager->syncShortcutsToUser(username)) {
                          qCWarning(couchplaySteam) << "Failed to sync Heroic shortcuts to" << username;
                          allSucceeded = false;
@@ -814,13 +767,12 @@ bool SessionRunner::setupLauncherAccess()
 
 QRect SessionRunner::getScreenGeometry() const
 {
-    // Get the primary screen geometry
     QScreen *screen = QGuiApplication::primaryScreen();
     if (screen) {
         return screen->geometry();
     }
 
-    // Fallback to a reasonable default
+    // Fallback: headless or no screen available
     return QRect(0, 0, 1920, 1080);
 }
 
@@ -929,21 +881,16 @@ QList<QRect> SessionRunner::calculateLayout(const QString &layout,
             result.append(QRect(x, y + i * instanceHeight, w, instanceHeight));
         }
     } else if (layout == QStringLiteral("grid")) {
-        // Grid layout with configurable behavior for 3 players:
-        // - gridSubLayout == "horizontal": 3×1 (each player gets full height, equal width) - DEFAULT for 3 players
-        // - gridSubLayout == "grid-2x2": 2×2 with empty cell (3 cells filled, 1 empty)
-        // - gridSubLayout == "left-right": player 1 left 40%, players 2+3 stacked right 60%
-        // - 2 players: 2×1
-        // - 4 players: 2×2
+        // 3-player grid sub-layouts:
+        //   "horizontal" (default): 3x1
+        //   "grid-2x2": 2x2 with empty cell
+        //   "left-right": player 1 left 40%, players 2+3 stacked right 60%
         if (instanceCount == 3 && gridSubLayout == QStringLiteral("left-right")) {
-            int leftWidth = w * 2 / 5;  // 40% for player 1
-            int rightWidth = w - leftWidth;  // 60% for players 2+3
+            int leftWidth = w * 2 / 5;
+            int rightWidth = w - leftWidth;
             int halfHeight = h / 2;
-            // Player 1: left, full height
             result.append(QRect(x, y, leftWidth, h));
-            // Player 2: top-right
             result.append(QRect(x + leftWidth, y, rightWidth, halfHeight));
-            // Player 3: bottom-right
             result.append(QRect(x + leftWidth, y + halfHeight, rightWidth, h - halfHeight));
         } else {
             int cols, rows;
@@ -973,15 +920,11 @@ QList<QRect> SessionRunner::calculateLayout(const QString &layout,
                 result.append(QRect(x + col * cellWidth, y + row * cellHeight, cellWidth, cellHeight));
             }
         }
-        }
     } else if (layout == QStringLiteral("multi-monitor")) {
-        // Each instance on a different monitor - just use full screen for now
-        // In a real implementation, we'd get each monitor's geometry
         for (int i = 0; i < instanceCount; ++i) {
             result.append(screenGeometry);
         }
     } else {
-        // Default to horizontal
         int instanceWidth = w / instanceCount;
         for (int i = 0; i < instanceCount; ++i) {
             result.append(QRect(x + i * instanceWidth, y, instanceWidth, h));
@@ -995,7 +938,6 @@ void SessionRunner::onInstanceStarted()
 {
     auto *instance = qobject_cast<GamescopeInstance*>(sender());
     if (instance) {
-        // Position the window after a short delay to allow it to appear
         positionInstanceWindow(instance);
         
         Q_EMIT instanceStarted(instance->index());
@@ -1012,7 +954,6 @@ void SessionRunner::onInstanceStopped()
         Q_EMIT instancesChanged();
         Q_EMIT runningInstanceCountChanged();
 
-        // Check if all instances have stopped
         if (!isRunning()) {
             setStatus(QStringLiteral("Session ended"));
             restoreDeviceOwnership();
@@ -1043,8 +984,6 @@ void SessionRunner::positionInstanceWindow(GamescopeInstance *instance)
     QRect targetGeometry = instance->windowGeometry();
     int instanceIndex = instance->index();
 
-    // Queue a position request - the WindowManager will find and position
-    // the next gamescope window that appears (excluding already-positioned ones)
     m_windowManager->queuePositionRequest(
         instanceIndex,
         targetGeometry,
@@ -1056,12 +995,11 @@ void SessionRunner::positionInstanceWindow(GamescopeInstance *instance)
 void SessionRunner::onWindowPositioned(int requestId, const QString &windowId)
 {
     Q_UNUSED(requestId)
-    // Track this window so it's excluded from future positioning
     if (!m_positionedWindowIds.contains(windowId)) {
         m_positionedWindowIds.append(windowId);
     }
 
-    // Start next instance in sequential launching mode
+    // Trigger next sequential instance launch
     if (!m_pendingInstanceConfigs.isEmpty()) {
         ++m_nextInstanceToStart;
         startNextInstance();
@@ -1083,21 +1021,19 @@ void SessionRunner::setupGlobalShortcut()
     m_stopAction->setText(i18nc("@action", "Stop CouchPlay Session"));
     m_stopAction->setProperty("componentName", QStringLiteral("couchplay"));
     
-    // Only stop if session is actually running
     connect(m_stopAction, &QAction::triggered, this, [this]() {
         if (isRunning()) {
             stop();
         }
     });
     
-    // Set default shortcut: Meta+Shift+Escape
+    // Default shortcut: Meta+Shift+Escape
     KGlobalAccel::setGlobalShortcut(m_stopAction, 
         QList<QKeySequence>() << QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Escape));
 }
 
 void SessionRunner::onDeviceReconnected(const QString &stableId, int eventNumber, int instanceIndex)
 {
-    // Only handle if session is running
     if (!isRunning()) {
         return;
     }
@@ -1111,7 +1047,6 @@ void SessionRunner::onDeviceReconnected(const QString &stableId, int eventNumber
         return;
     }
     
-    // Get the username for this instance
     const auto &profile = m_sessionManager->currentProfile();
     if (instanceIndex < 0 || instanceIndex >= profile.instances.size()) {
         qWarning() << "SessionRunner: Invalid instance index" << instanceIndex << "for reconnected device";
@@ -1124,7 +1059,6 @@ void SessionRunner::onDeviceReconnected(const QString &stableId, int eventNumber
         return;
     }
     
-    // Get UID for this user
     struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
     if (!pw) {
         qWarning() << "SessionRunner: User" << username << "not found";
@@ -1132,13 +1066,11 @@ void SessionRunner::onDeviceReconnected(const QString &stableId, int eventNumber
     }
     int uid = static_cast<int>(pw->pw_uid);
     
-    // Construct the new device path
     QString devicePath = QStringLiteral("/dev/input/event%1").arg(eventNumber);
     
     qDebug() << "SessionRunner: Device reconnected, restoring ownership:"
              << devicePath << "(stableId:" << stableId << ") to user" << username;
     
-    // Set ownership on the reconnected device
     if (m_helperClient->setDeviceOwner(devicePath, uid)) {
         if (!m_ownedDevicePaths.contains(devicePath)) {
             m_ownedDevicePaths.append(devicePath);
@@ -1208,9 +1140,8 @@ qint64 SessionRunner::findSteamProcess(qint64 gamescopePid, int maxDepth) const
     return 0;
 }
 
-// DEVIATION: Synchronous /proc/<pid>/fd/ traversal (see AGENTS.md anti-patterns).
+// Synchronous /proc/<pid>/fd/ traversal (see AGENTS.md anti-patterns).
 // Steam has bounded FDs and VirtualDeviceWatcher debounces, so impact is minimal.
-// TODO: Move to QThread if latency becomes measurable.
 bool SessionRunner::hasUinputOpen(qint64 pid) const
 {
     QString fdDir = QStringLiteral("/proc/%1/fd").arg(pid);

--- a/src/core/SessionRunner.cpp
+++ b/src/core/SessionRunner.cpp
@@ -225,7 +225,7 @@ bool SessionRunner::start()
 
     // Calculate window layouts
     QRect screenGeometry = getScreenGeometry();
-    QList<QRect> layouts = calculateLayout(profile.layout, instanceCount, screenGeometry);
+    m_layouts = calculateLayout(profile.layout, instanceCount, screenGeometry, profile.gridSubLayout);
 
     // Set up device ownership (requires polkit helper)
     if (!setupDeviceOwnership()) {
@@ -245,15 +245,10 @@ bool SessionRunner::start()
         qWarning() << "Failed to set up launcher access - continuing anyway";
     }
 
-    // Create and start instances
+    // Build pending configs for sequential launching (fixes race condition with window positioning)
+    m_pendingInstanceConfigs.clear();
     for (int i = 0; i < instanceCount; ++i) {
         const InstanceConfig &instConfig = profile.instances[i];
-        
-        // Create instance
-        auto *instance = new GamescopeInstance(this);
-        connect(instance, &GamescopeInstance::started, this, &SessionRunner::onInstanceStarted);
-        connect(instance, &GamescopeInstance::stopped, this, &SessionRunner::onInstanceStopped);
-        connect(instance, &GamescopeInstance::errorOccurred, this, &SessionRunner::onInstanceError);
 
         // Build config map for the instance
         QVariantMap config;
@@ -262,12 +257,12 @@ bool SessionRunner::start()
         
         // Derive resolution from layout - internal resolution matches output resolution
         // This ensures games render at the correct size for their window
-        config[QStringLiteral("internalWidth")] = layouts[i].width();
-        config[QStringLiteral("internalHeight")] = layouts[i].height();
-        config[QStringLiteral("outputWidth")] = layouts[i].width();
-        config[QStringLiteral("outputHeight")] = layouts[i].height();
-        config[QStringLiteral("positionX")] = layouts[i].x();
-        config[QStringLiteral("positionY")] = layouts[i].y();
+        config[QStringLiteral("internalWidth")] = m_layouts[i].width();
+        config[QStringLiteral("internalHeight")] = m_layouts[i].height();
+        config[QStringLiteral("outputWidth")] = m_layouts[i].width();
+        config[QStringLiteral("outputHeight")] = m_layouts[i].height();
+        config[QStringLiteral("positionX")] = m_layouts[i].x();
+        config[QStringLiteral("positionY")] = m_layouts[i].y();
         config[QStringLiteral("refreshRate")] = instConfig.refreshRate;
         config[QStringLiteral("scalingMode")] = instConfig.scalingMode;
         config[QStringLiteral("filterMode")] = instConfig.filterMode;
@@ -306,18 +301,12 @@ bool SessionRunner::start()
             config[QStringLiteral("bindPaths")] = m_instanceBindPaths.value(i);
         }
 
-        m_instances.append(instance);
-
-        // Start with slight delay between instances to avoid resource contention
-        if (!instance->start(config, i)) {
-            qWarning() << "Failed to start instance" << i;
-        }
+        m_pendingInstanceConfigs.append(config);
     }
 
-    setStatus(QStringLiteral("Session running"));
-    Q_EMIT runningChanged();
-    Q_EMIT instancesChanged();
-    Q_EMIT sessionStarted();
+    // Start instances sequentially to ensure correct window positioning order
+    m_nextInstanceToStart = 0;
+    startNextInstance();
 
     QSet<int> knownEventNumbers;
     if (m_deviceManager) {
@@ -436,6 +425,42 @@ QVariantList SessionRunner::instancesAsVariant() const
     return list;
 }
 
+void SessionRunner::startNextInstance()
+{
+    // Check if all instances have been started
+    if (m_nextInstanceToStart >= m_pendingInstanceConfigs.size()) {
+        // All instances started - session is now fully running
+        setStatus(QStringLiteral("Session running"));
+        Q_EMIT runningChanged();
+        Q_EMIT instancesChanged();
+        Q_EMIT sessionStarted();
+        return;
+    }
+
+    int index = m_nextInstanceToStart;
+    const QVariantMap &config = m_pendingInstanceConfigs[index];
+
+    // Create instance
+    auto *instance = new GamescopeInstance(this);
+    connect(instance, &GamescopeInstance::started, this, &SessionRunner::onInstanceStarted);
+    connect(instance, &GamescopeInstance::stopped, this, &SessionRunner::onInstanceStopped);
+    connect(instance, &GamescopeInstance::errorOccurred, this, &SessionRunner::onInstanceError);
+
+    m_instances.append(instance);
+
+    // Start the instance
+    if (!instance->start(config, index)) {
+        qWarning() << "Failed to start instance" << index;
+    }
+
+    // If KWin is not available, start next instance immediately (no window positioning to wait for)
+    if (!m_windowManager || !m_windowManager->isAvailable()) {
+        ++m_nextInstanceToStart;
+        startNextInstance();
+    }
+    // Otherwise, wait for onWindowPositioned to trigger the next start
+}
+
 void SessionRunner::cleanupInstances()
 {
     // Cancel any pending window positioning requests
@@ -448,6 +473,11 @@ void SessionRunner::cleanupInstances()
     }
     m_instances.clear();
     m_positionedWindowIds.clear(); // Clear tracked window IDs for next session
+    
+    // Clear sequential launching state
+    m_pendingInstanceConfigs.clear();
+    m_layouts.clear();
+    m_nextInstanceToStart = 0;
 }
 
 void SessionRunner::cleanupOverrideDirs(const QStringList &overridePaths)
@@ -872,7 +902,8 @@ void SessionRunner::loadOverrideFiles(const QString &overridesRoot, const QStrin
 
 QList<QRect> SessionRunner::calculateLayout(const QString &layout,
                                              int instanceCount,
-                                             const QRect &screenGeometry)
+                                             const QRect &screenGeometry,
+                                             const QString &gridSubLayout)
 {
     QList<QRect> result;
 
@@ -898,18 +929,50 @@ QList<QRect> SessionRunner::calculateLayout(const QString &layout,
             result.append(QRect(x, y + i * instanceHeight, w, instanceHeight));
         }
     } else if (layout == QStringLiteral("grid")) {
-        // Grid layout: 2 columns for 3+ players, match count for 1-2
-        // Uses same formula as SessionManager::recalculateOutputResolutions()
-        int cols = (instanceCount <= 2) ? instanceCount : 2;
-        int rows = (instanceCount + cols - 1) / cols;
-        
-        int cellWidth = w / cols;
-        int cellHeight = h / rows;
-        
-        for (int i = 0; i < instanceCount; ++i) {
-            int col = i % cols;
-            int row = i / cols;
-            result.append(QRect(x + col * cellWidth, y + row * cellHeight, cellWidth, cellHeight));
+        // Grid layout with configurable behavior for 3 players:
+        // - gridSubLayout == "horizontal": 3×1 (each player gets full height, equal width) - DEFAULT for 3 players
+        // - gridSubLayout == "grid-2x2": 2×2 with empty cell (3 cells filled, 1 empty)
+        // - gridSubLayout == "left-right": player 1 left 40%, players 2+3 stacked right 60%
+        // - 2 players: 2×1
+        // - 4 players: 2×2
+        if (instanceCount == 3 && gridSubLayout == QStringLiteral("left-right")) {
+            int leftWidth = w * 2 / 5;  // 40% for player 1
+            int rightWidth = w - leftWidth;  // 60% for players 2+3
+            int halfHeight = h / 2;
+            // Player 1: left, full height
+            result.append(QRect(x, y, leftWidth, h));
+            // Player 2: top-right
+            result.append(QRect(x + leftWidth, y, rightWidth, halfHeight));
+            // Player 3: bottom-right
+            result.append(QRect(x + leftWidth, y + halfHeight, rightWidth, h - halfHeight));
+        } else {
+            int cols, rows;
+            if (instanceCount == 3) {
+                if (gridSubLayout == QStringLiteral("grid-2x2")) {
+                    cols = 2;
+                    rows = 2;
+                } else {
+                    // Default for 3 players: horizontal (3×1)
+                    cols = 3;
+                    rows = 1;
+                }
+            } else if (instanceCount <= 2) {
+                cols = 2;
+                rows = 1;
+            } else {
+                cols = 2;
+                rows = 2;
+            }
+
+            int cellWidth = w / cols;
+            int cellHeight = h / rows;
+
+            for (int i = 0; i < instanceCount; ++i) {
+                int col = i % cols;
+                int row = i / cols;
+                result.append(QRect(x + col * cellWidth, y + row * cellHeight, cellWidth, cellHeight));
+            }
+        }
         }
     } else if (layout == QStringLiteral("multi-monitor")) {
         // Each instance on a different monitor - just use full screen for now
@@ -997,13 +1060,20 @@ void SessionRunner::onWindowPositioned(int requestId, const QString &windowId)
     if (!m_positionedWindowIds.contains(windowId)) {
         m_positionedWindowIds.append(windowId);
     }
+
+    // Start next instance in sequential launching mode
+    if (!m_pendingInstanceConfigs.isEmpty()) {
+        ++m_nextInstanceToStart;
+        startNextInstance();
+    }
 }
 
 void SessionRunner::onWindowPositioningTimeout(int requestId)
 {
     qWarning() << "SessionRunner: Failed to position window for instance" << requestId 
-               << "after timeout";
-    Q_EMIT errorOccurred(QStringLiteral("Failed to position window for instance %1").arg(requestId));
+               << "after timeout - stopping session";
+    Q_EMIT errorOccurred(QStringLiteral("Failed to position window for instance %1. Session stopped.").arg(requestId));
+    stop();
 }
 
 void SessionRunner::setupGlobalShortcut()

--- a/src/core/SessionRunner.h
+++ b/src/core/SessionRunner.h
@@ -124,11 +124,13 @@ public:
      * @param layout Layout type: "horizontal", "vertical", "multi-monitor", "grid"
      * @param instanceCount Number of instances
      * @param screenGeometry Available screen geometry
+     * @param gridSubLayout For "grid" layout with 3 players: "horizontal" (3×1), "grid-2x2" (2×2 with gap), or empty (defaults to horizontal)
      * @return List of QRect geometries for each instance
      */
     static QList<QRect> calculateLayout(const QString &layout, 
                                          int instanceCount,
-                                         const QRect &screenGeometry);
+                                         const QRect &screenGeometry,
+                                         const QString &gridSubLayout = QString());
 
     static QString getOverridesRootPath(const QString &presetId, const QString &gameKeyHash);
 
@@ -165,6 +167,7 @@ private Q_SLOTS:
     void onWindowPositioningTimeout(int requestId);
     void onDeviceReconnected(const QString &stableId, int eventNumber, int instanceIndex);
     void onVirtualDeviceAppeared(int eventNumber, const QString &devicePath, const QString &deviceName);
+    void startNextInstance();
 
 private:
     void setStatus(const QString &status);
@@ -203,4 +206,9 @@ private:
     QStringList m_ownedDevicePaths; // Devices we've taken ownership of
     QStringList m_positionedWindowIds; // Window IDs we've positioned (for excluding)
     bool m_borderlessWindows = false; // Default to decorated windows
+    
+    // Sequential instance launching state
+    int m_nextInstanceToStart = 0;
+    QList<QVariantMap> m_pendingInstanceConfigs;
+    QList<QRect> m_layouts;
 };

--- a/src/core/WindowManager.cpp
+++ b/src/core/WindowManager.cpp
@@ -17,7 +17,6 @@
 WindowManager::WindowManager(QObject *parent)
     : QObject(parent)
 {
-    // Check if KWin is available
     QDBusInterface kwin(
         QStringLiteral("org.kde.KWin"),
         QStringLiteral("/KWin"),
@@ -32,12 +31,11 @@ WindowManager::WindowManager(QObject *parent)
         qDebug() << "WindowManager: KWin D-Bus interface available";
     }
     
-    // Create the monitoring timer (but don't start it yet)
     m_monitorTimer = new QTimer(this);
     m_monitorTimer->setInterval(MONITOR_INTERVAL_MS);
     connect(m_monitorTimer, &QTimer::timeout, this, &WindowManager::checkForNewWindows);
 
-    // Clean up stale KWin scripts from previous runs that may have crashed
+    // Clean up stale KWin scripts from previous runs
     QString runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
     QString couchplayRuntimeDir = runtimeDir + QStringLiteral("/couchplay");
     QDir staleDir(couchplayRuntimeDir);
@@ -86,8 +84,6 @@ QStringList WindowManager::findAllGamescopeWindows()
         return results;
     }
 
-    // Use WindowsRunner to search for windows
-    // The Match method returns windows matching a search query
     QDBusInterface windowsRunner(
         QStringLiteral("org.kde.KWin"),
         QStringLiteral("/WindowsRunner"),
@@ -137,7 +133,6 @@ QStringList WindowManager::findAllGamescopeWindows()
         quint32 relevance;
         double score;
         
-        // Read the first 5 fields we care about
         arg >> matchId >> caption >> iconName >> relevance >> score;
         
         // Skip the properties dict - it contains complex types that are hard to parse
@@ -151,7 +146,6 @@ QStringList WindowManager::findAllGamescopeWindows()
         if (matchId.contains(QLatin1Char('{'))) {
             QString uuid = matchId.mid(matchId.indexOf(QLatin1Char('{')));
             
-            // Get window info to check if it's a gamescope window
             QVariantMap info = getWindowInfo(uuid);
             QString desktopFile = info.value(QStringLiteral("desktopFile")).toString();
             QString resourceClass = info.value(QStringLiteral("resourceClass")).toString();
@@ -225,7 +219,6 @@ bool WindowManager::positionWindow(const QString &windowId, const QRect &geometr
 
     qDebug() << "WindowManager: Positioning window" << windowId << "to" << geometry;
 
-    // Use KWin scripting to position the window
     return executePositionScript(windowId, geometry);
 }
 
@@ -239,7 +232,6 @@ void WindowManager::queuePositionRequest(int requestId, const QRect &geometry,
         return;
     }
     
-    // Check if a request with this ID already exists
     for (int i = 0; i < m_pendingRequests.size(); ++i) {
         if (m_pendingRequests[i].requestId == requestId) {
             qWarning() << "WindowManager: Replacing existing request" << requestId;
@@ -261,10 +253,7 @@ void WindowManager::queuePositionRequest(int requestId, const QRect &geometry,
              << "excluding" << excludeWindowIds.size() << "windows"
              << "timeout:" << timeoutMs << "ms";
     
-    // Start monitoring if not already running
     startMonitoring();
-    
-    // Do an immediate check in case the window is already there
     checkForNewWindows();
 }
 
@@ -305,7 +294,6 @@ void WindowManager::checkForNewWindows()
     
     qint64 now = QDateTime::currentMSecsSinceEpoch();
     
-    // Check for expired requests first
     QList<int> expiredRequestIds;
     for (int i = m_pendingRequests.size() - 1; i >= 0; --i) {
         if (m_pendingRequests[i].expiresAt <= now) {
@@ -314,7 +302,6 @@ void WindowManager::checkForNewWindows()
         }
     }
     
-    // Emit timeout signals for expired requests
     for (int requestId : expiredRequestIds) {
         qWarning() << "WindowManager: Position request" << requestId << "timed out";
         Q_EMIT positioningTimedOut(requestId);
@@ -325,16 +312,13 @@ void WindowManager::checkForNewWindows()
         return;
     }
     
-    // Find all current gamescope windows
     QStringList currentWindows = findAllGamescopeWindows();
     
-    // Process pending requests in order (FIFO)
-    // We iterate carefully since we may remove elements
+    // Process pending requests in order (FIFO) — we may remove elements during iteration
     int i = 0;
     while (i < m_pendingRequests.size() && !currentWindows.isEmpty()) {
         const PositionRequest &request = m_pendingRequests[i];
         
-        // Find a window that matches this request (not in exclude list and not already known)
         QString matchedWindowId;
         for (const QString &windowId : currentWindows) {
             if (!request.excludeWindowIds.contains(windowId) && 
@@ -345,19 +329,15 @@ void WindowManager::checkForNewWindows()
         }
         
         if (!matchedWindowId.isEmpty()) {
-            // Found a match - position the window
             qDebug() << "WindowManager: Matched window" << matchedWindowId 
                      << "to request" << request.requestId;
             
             bool success = positionWindow(matchedWindowId, request.geometry);
             
-            // Track this window as known (positioned)
             m_knownWindowIds.append(matchedWindowId);
             
-            // Remove from available windows for subsequent requests
             currentWindows.removeAll(matchedWindowId);
             
-            // Remove this request and emit signal
             int requestId = request.requestId;
             m_pendingRequests.removeAt(i);
             
@@ -369,7 +349,6 @@ void WindowManager::checkForNewWindows()
             
             // Don't increment i since we removed the current element
         } else {
-            // No match for this request, try next
             ++i;
         }
     }
@@ -395,9 +374,6 @@ void WindowManager::stopMonitoringIfEmpty()
 
 bool WindowManager::executePositionScript(const QString &windowId, const QRect &geometry)
 {
-    // Create a temporary KWin script to position the window
-    // KWin scripts use JavaScript and can access window properties
-    
     QString scriptContent = QStringLiteral(R"(
 (function() {
     var targetUuid = "%1";
@@ -447,7 +423,6 @@ bool WindowManager::executePositionScript(const QString &windowId, const QRect &
     scriptFile.write(scriptContent.toUtf8());
     scriptFile.close();
     
-    // Load the script via KWin D-Bus
     QDBusInterface scripting(
         QStringLiteral("org.kde.KWin"),
         QStringLiteral("/Scripting"),
@@ -462,11 +437,9 @@ bool WindowManager::executePositionScript(const QString &windowId, const QRect &
         return false;
     }
     
-    // Generate a unique plugin name for this positioning operation
     QString pluginName = QStringLiteral("couchplay-position-%1").arg(
         QString::number(QDateTime::currentMSecsSinceEpoch()));
     
-    // Load the script
     QDBusReply<int> loadReply = scripting.call(QStringLiteral("loadScript"), scriptPath, pluginName);
     
     if (!loadReply.isValid()) {
@@ -479,17 +452,14 @@ bool WindowManager::executePositionScript(const QString &windowId, const QRect &
     int scriptId = loadReply.value();
     qDebug() << "WindowManager: Loaded positioning script with ID" << scriptId;
     
-    // Start the scripts (this actually executes them)
     scripting.call(QStringLiteral("start"));
     
     // Give the script a moment to execute - use QTimer for non-blocking delay would be better
     // but for simplicity we use a short blocking wait here
     QThread::msleep(100);
     
-    // Unload the script
     scripting.call(QStringLiteral("unloadScript"), pluginName);
     
-    // Clean up the temporary file
     QFile::remove(scriptPath);
     
     Q_EMIT windowPositioned(windowId, geometry);

--- a/src/dbus/CouchPlayHelperClient.cpp
+++ b/src/dbus/CouchPlayHelperClient.cpp
@@ -31,7 +31,6 @@ CouchPlayHelperClient::CouchPlayHelperClient(QObject *parent)
         return;
     }
 
-    // Verify we can actually call a method
     QDBusReply<QString> reply = m_interface->call(QStringLiteral("Version"));
     if (reply.isValid()) {
         qWarning() << "CouchPlay helper connected, version:" << reply.value();
@@ -128,8 +127,6 @@ bool CouchPlayHelperClient::createUser(const QString &username)
         return false;
     }
 
-    // The helper expects username and fullName parameters
-    // Use a default fullName based on the username
     QString fullName = QStringLiteral("CouchPlay Player (%1)").arg(username);
 
     QDBusReply<uint> reply = m_interface->call(
@@ -143,7 +140,6 @@ bool CouchPlayHelperClient::createUser(const QString &username)
         return false;
     }
 
-    // CreateUser returns the UID of the new user, or 0 on failure
     return reply.value() > 0;
 }
 
@@ -264,7 +260,6 @@ int CouchPlayHelperClient::mountSharedDirectories(const QString &username, uint 
     }
 
     if (directories.isEmpty()) {
-        // Nothing to mount, that's fine
         return 0;
     }
 

--- a/src/dbus/CouchPlayHelperClient.h
+++ b/src/dbus/CouchPlayHelperClient.h
@@ -22,14 +22,8 @@ public:
     explicit CouchPlayHelperClient(QObject *parent = nullptr);
     ~CouchPlayHelperClient() override;
 
-    /**
-     * @brief Check if the helper is available
-     */
     virtual bool isAvailable() const { return m_available; }
 
-    /**
-     * @brief Set device ownership for a specific user
-     */
     Q_INVOKABLE bool setDeviceOwner(const QString &devicePath, int uid);
 
     /**
@@ -37,14 +31,8 @@ public:
      */
     Q_INVOKABLE bool restoreDeviceOwner(const QString &devicePath);
 
-    /**
-     * @brief Restore all modified devices
-     */
     Q_INVOKABLE void restoreAllDevices();
 
-    /**
-     * @brief Create a new user account
-     */
     Q_INVOKABLE bool createUser(const QString &username);
 
     /**
@@ -57,12 +45,6 @@ public:
      */
     Q_INVOKABLE bool deleteUser(const QString &username, bool removeHome);
 
-    /**
-     * @brief Check if a user is in the couchplay group
-     * 
-     * @param username Username to check
-     * @return true if user is in couchplay group
-     */
     Q_INVOKABLE bool isInCouchPlayGroup(const QString &username);
 
     /**
@@ -95,9 +77,6 @@ public:
      */
     Q_INVOKABLE bool killInstance(qint64 pid);
 
-    /**
-     * @brief Check helper availability
-     */
     Q_INVOKABLE void checkAvailability();
 
     /**

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -16,7 +16,6 @@ Kirigami.ApplicationWindow {
     minimumWidth: Kirigami.Units.gridUnit * 40
     minimumHeight: Kirigami.Units.gridUnit * 30
 
-    // Backend managers
     SettingsManager {
         id: settingsManager
     }
@@ -25,17 +24,14 @@ Kirigami.ApplicationWindow {
         id: deviceManager
         settingsManager: settingsManager
         
-        // When a device is assigned or unassigned, update the stableIds and names in SessionManager
         onDeviceAssigned: function(eventNumber, instanceIndex, previousInstanceIndex) {
             if (sessionManager) {
-                // Update the new instance (if assigning to an instance)
                 if (instanceIndex >= 0) {
                     let stableIds = deviceManager.getStableIdsForInstance(instanceIndex)
                     let names = deviceManager.getDeviceNamesForInstance(instanceIndex)
                     sessionManager.setInstanceDeviceStableIds(instanceIndex, stableIds, names)
                 }
                 
-                // Update the previous instance (if it was assigned somewhere before)
                 if (previousInstanceIndex >= 0 && previousInstanceIndex !== instanceIndex) {
                     let stableIds = deviceManager.getStableIdsForInstance(previousInstanceIndex)
                     let names = deviceManager.getDeviceNamesForInstance(previousInstanceIndex)
@@ -44,7 +40,6 @@ Kirigami.ApplicationWindow {
             }
         }
         
-        // When a pending device reconnects and is auto-restored
         onDeviceAutoRestored: function(name, instanceIndex) {
             applicationWindow().showPassiveNotification(
                 i18nc("@info", "%1 reconnected to Player %2", name, instanceIndex + 1))
@@ -54,13 +49,10 @@ Kirigami.ApplicationWindow {
     SessionManager {
         id: sessionManager
         
-        // When a profile is loaded, restore device assignments from stableIds
         onProfileLoaded: function(deviceInfoByInstance) {
             if (deviceManager) {
-                // Clear ALL existing assignments before restoring (prevents stale assignments from previous session/profile)
                 deviceManager.unassignAll()
                 
-                // Restore assignments for each instance that has saved stableIds
                 for (let instanceStr in deviceInfoByInstance) {
                     let instanceIndex = parseInt(instanceStr)
                     let info = deviceInfoByInstance[instanceStr]
@@ -148,68 +140,27 @@ Kirigami.ApplicationWindow {
             Kirigami.Action {
                 icon.name: "go-home"
                 text: i18nc("@action:button", "Home")
-                onTriggered: {
-                    pageStack.clear()
-                    pageStack.push(homePage, {
-                        sessionManager: sessionManager,
-                        sessionRunner: sessionRunner,
-                        deviceManager: deviceManager,
-                        helperClient: helperClient
-                    })
-                }
+                onTriggered: pushHomePage()
             },
             Kirigami.Action {
                 icon.name: "list-add"
                 text: i18nc("@action:button", "New Session")
-                onTriggered: {
-                    pageStack.clear()
-                    pageStack.push(sessionSetupPage, {
-                        sessionManager: sessionManager,
-                        sessionRunner: sessionRunner,
-                        deviceManager: deviceManager,
-                        monitorManager: monitorManager,
-                        userManager: userManager,
-                        presetManager: presetManager
-                    })
-                }
+                onTriggered: pushSessionSetupPage()
             },
             Kirigami.Action {
                 icon.name: "bookmark"
                 text: i18nc("@action:button", "Profiles")
-                onTriggered: {
-                    pageStack.clear()
-                    pageStack.push(profilesPage, {
-                        sessionManager: sessionManager,
-                        sessionRunner: sessionRunner
-                    })
-                }
+                onTriggered: pushProfilesPage()
             },
             Kirigami.Action {
                 icon.name: "system-users"
                 text: i18nc("@action:button", "Users")
-                onTriggered: {
-                    pageStack.clear()
-                    pageStack.push(usersPage, {
-                        userManager: userManager,
-                        helperClient: helperClient
-                    })
-                }
+                onTriggered: pushUsersPage()
             },
             Kirigami.Action {
                 icon.name: "configure"
                 text: i18nc("@action:button", "Settings")
-                onTriggered: {
-                    pageStack.clear()
-                    pageStack.push(settingsPage, {
-                        sessionRunner: sessionRunner,
-                        helperClient: helperClient,
-                        presetManager: presetManager,
-                        steamConfigManager: steamConfigManager,
-                        settingsManager: settingsManager,
-                        heroicConfigManager: heroicConfigManager,
-                        audioManager: audioManager
-                    })
-                }
+                onTriggered: pushSettingsPage()
             }
         ]
     }
@@ -221,7 +172,6 @@ Kirigami.ApplicationWindow {
         helperClient: helperClient
     }
 
-    // Page components - properties must be passed via pageStack.push()
     Component {
         id: homePage
         HomePage {}
@@ -252,8 +202,6 @@ Kirigami.ApplicationWindow {
         SettingsPage {}
     }
 
-    // Helper functions to push pages with required properties
-    // All use clear() + push() to prevent split-view stacking
     function pushHomePage() {
         pageStack.clear()
         pageStack.push(homePage, {

--- a/src/qml/pages/DeviceAssignmentPage.qml
+++ b/src/qml/pages/DeviceAssignmentPage.qml
@@ -11,7 +11,6 @@ Kirigami.ScrollablePage {
     
     title: i18nc("@title", "Assign Devices")
     
-    // Reference to DeviceManager (injected from parent)
     required property var deviceManager
     property int instanceCount: 2
 
@@ -52,7 +51,6 @@ Kirigami.ScrollablePage {
     ColumnLayout {
         spacing: Kirigami.Units.largeSpacing
 
-        // Player count and filter controls
         RowLayout {
             Layout.fillWidth: true
             spacing: Kirigami.Units.smallSpacing
@@ -81,7 +79,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Instructions
         Kirigami.InlineMessage {
             Layout.fillWidth: true
             type: Kirigami.MessageType.Information
@@ -89,7 +86,6 @@ Kirigami.ScrollablePage {
             visible: true
         }
 
-        // Player drop zones
         RowLayout {
             Layout.fillWidth: true
             spacing: Kirigami.Units.largeSpacing
@@ -121,13 +117,11 @@ Kirigami.ScrollablePage {
             Layout.fillWidth: true
         }
 
-        // Available devices section
         Kirigami.Heading {
             level: 3
             text: i18nc("@title:group", "Available Devices")
         }
 
-        // Device type tabs
         QQC2.TabBar {
             id: deviceTypeBar
             Layout.fillWidth: true
@@ -150,7 +144,6 @@ Kirigami.ScrollablePage {
             Layout.fillWidth: true
             currentIndex: deviceTypeBar.currentIndex
 
-            // Controllers list
             DeviceList {
                 deviceModel: deviceManager?.controllers ?? []
                 deviceType: "controller"
@@ -163,7 +156,6 @@ Kirigami.ScrollablePage {
                 }
             }
 
-            // Keyboards list
             DeviceList {
                 deviceModel: deviceManager?.keyboards ?? []
                 deviceType: "keyboard"
@@ -176,7 +168,6 @@ Kirigami.ScrollablePage {
                 }
             }
 
-            // Mice list
             DeviceList {
                 deviceModel: deviceManager?.mice ?? []
                 deviceType: "mouse"
@@ -190,7 +181,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Empty state
         Kirigami.PlaceholderMessage {
             Layout.fillWidth: true
             visible: (deviceManager?.visibleDevices?.length ?? 0) === 0
@@ -206,7 +196,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Player drop zone component
     component PlayerDropZone: Kirigami.AbstractCard {
         id: dropZone
         
@@ -243,7 +232,6 @@ Kirigami.ScrollablePage {
             spacing: Kirigami.Units.smallSpacing
             clip: true
 
-            // Show assigned devices
             Repeater {
                 model: dropZone.assignedDevices
 
@@ -263,7 +251,6 @@ Kirigami.ScrollablePage {
                 }
             }
 
-            // Empty state for drop zone
             Kirigami.PlaceholderMessage {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -293,7 +280,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Device list component
     component DeviceList: ColumnLayout {
         id: deviceListRoot
         
@@ -328,7 +314,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Empty state for this device type
         Kirigami.PlaceholderMessage {
             Layout.fillWidth: true
             visible: deviceListRoot.deviceModel.length === 0
@@ -351,7 +336,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Draggable device card component
     component DraggableDeviceCard: Kirigami.AbstractCard {
         id: deviceCard
         
@@ -364,7 +348,6 @@ Kirigami.ScrollablePage {
 
         property bool isDragging: false
         
-        // Guard against undefined device
         visible: deviceCard.device !== undefined && deviceCard.device !== null
 
         contentItem: RowLayout {
@@ -404,7 +387,6 @@ Kirigami.ScrollablePage {
                 }
             }
 
-            // Assignment indicator
             Kirigami.Chip {
                 visible: deviceCard.device?.assigned ?? false
                 text: i18nc("@info", "Player %1", (deviceCard.device?.assignedInstance ?? 0) + 1)
@@ -416,7 +398,6 @@ Kirigami.ScrollablePage {
                 }
             }
 
-            // Quick assign buttons
             Repeater {
                 model: deviceCard.instanceCount
                 
@@ -437,7 +418,6 @@ Kirigami.ScrollablePage {
                 }
             }
 
-            // Identify button (controllers only)
             QQC2.Button {
                 icon.name: "flashlight-on"
                 flat: true
@@ -453,7 +433,6 @@ Kirigami.ScrollablePage {
                 }
             }
 
-            // Ignore button
             QQC2.Button {
                 icon.name: "dialog-cancel"
                 flat: true
@@ -470,7 +449,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Drag support
         Drag.active: dragArea.drag.active
         Drag.keys: ["application/x-couchplay-device"]
         Drag.mimeData: { "text/plain": (deviceCard.device?.eventNumber ?? 0).toString() }

--- a/src/qml/pages/ProfilesPage.qml
+++ b/src/qml/pages/ProfilesPage.qml
@@ -10,11 +10,9 @@ Kirigami.ScrollablePage {
     id: root
     title: i18nc("@title", "Profiles")
 
-    // Backend managers (from Main.qml)
     required property var sessionManager
     required property var sessionRunner
 
-    // Refresh profiles when page becomes visible
     Component.onCompleted: {
         if (sessionManager) {
             sessionManager.refreshProfiles()
@@ -36,7 +34,6 @@ Kirigami.ScrollablePage {
         }
     ]
 
-    // Delete confirmation dialog
     Kirigami.PromptDialog {
         id: deleteDialog
         title: i18nc("@title:dialog", "Delete Profile")
@@ -53,12 +50,10 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Main content
     ColumnLayout {
         spacing: Kirigami.Units.largeSpacing
         visible: (sessionManager?.savedProfiles?.length ?? 0) > 0
 
-        // Profile grid
         GridLayout {
             Layout.fillWidth: true
             columns: Math.max(1, Math.floor(root.width / (Kirigami.Units.gridUnit * 20)))
@@ -106,7 +101,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Empty state
     Kirigami.PlaceholderMessage {
         anchors.centerIn: parent
         visible: (sessionManager?.savedProfiles?.length ?? 0) === 0
@@ -125,7 +119,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Profile card component - Minimal Modern Design
     component ProfileCard: Kirigami.AbstractCard {
         id: profileCard
 
@@ -150,12 +143,10 @@ Kirigami.ScrollablePage {
         contentItem: ColumnLayout {
             spacing: Kirigami.Units.smallSpacing
 
-            // Top section: Icon and title
             RowLayout {
                 Layout.fillWidth: true
                 spacing: Kirigami.Units.mediumSpacing
 
-                // Large profile icon
                 Rectangle {
                     Layout.preferredWidth: Kirigami.Units.iconSizes.large
                     Layout.preferredHeight: Kirigami.Units.iconSizes.large
@@ -171,7 +162,6 @@ Kirigami.ScrollablePage {
                     }
                 }
 
-                // Title and subtitle
                 ColumnLayout {
                     Layout.fillWidth: true
                     spacing: 2
@@ -221,7 +211,6 @@ Kirigami.ScrollablePage {
                     }
                 }
 
-                // Status indicator (top right)
                 Kirigami.Chip {
                     visible: profileCard.isCurrentProfile
                     text: i18nc("@info", "Loaded")
@@ -231,7 +220,6 @@ Kirigami.ScrollablePage {
                 }
             }
 
-            // Action buttons row
             RowLayout {
                 Layout.fillWidth: true
                 spacing: Kirigami.Units.smallSpacing

--- a/src/qml/pages/SessionSetupPage.qml
+++ b/src/qml/pages/SessionSetupPage.qml
@@ -24,6 +24,7 @@ Kirigami.ScrollablePage {
     // Sync with session manager
     property int instanceCount: sessionManager ? sessionManager.instanceCount : 2
     property string layoutMode: sessionManager ? sessionManager.currentLayout : "horizontal"
+    property string gridSubLayout: sessionManager ? sessionManager.currentGridSubLayout : ""
 
     // Revision counter to force re-evaluation of user filtering when instances change
     property int instancesRevision: 0
@@ -80,6 +81,14 @@ Kirigami.ScrollablePage {
         if (sessionManager) {
             sessionManager.currentLayout = layoutMode
             // Recalculate output resolutions based on screen size
+            let screenSize = getPrimaryMonitorSize()
+            sessionManager.recalculateOutputResolutions(screenSize.width, screenSize.height)
+        }
+    }
+
+    onGridSubLayoutChanged: {
+        if (sessionManager && sessionManager.currentLayout === "grid") {
+            sessionManager.currentGridSubLayout = gridSubLayout
             let screenSize = getPrimaryMonitorSize()
             sessionManager.recalculateOutputResolutions(screenSize.width, screenSize.height)
         }
@@ -236,7 +245,13 @@ Kirigami.ScrollablePage {
                 layoutType: "grid"
                 selected: layoutMode === "grid"
                 title: i18nc("@option", "Grid")
-                description: i18nc("@info", "2x2 grid layout")
+                description: root.instanceCount === 3
+                    ? (root.gridSubLayout === "grid-2x2"
+                        ? i18nc("@info", "2×2 grid with one empty cell")
+                        : root.gridSubLayout === "left-right"
+                            ? i18nc("@info", "Player 1 left, players 2–3 right")
+                            : i18nc("@info", "3×1 horizontal layout"))
+                    : i18nc("@info", "2×2 grid layout")
                 instanceCount: root.instanceCount
                 visible: root.instanceCount > 2
                 onClicked: layoutMode = "grid"
@@ -251,6 +266,46 @@ Kirigami.ScrollablePage {
                 description: i18nc("@info", "One instance per monitor")
                 instanceCount: root.instanceCount
                 onClicked: layoutMode = "multi-monitor"
+            }
+        }
+
+        // Grid sub-layout selector (only visible when grid is selected and 3 players)
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.topMargin: Kirigami.Units.smallSpacing
+            Layout.leftMargin: Kirigami.Units.largeSpacing
+            visible: layoutMode === "grid" && root.instanceCount === 3
+            spacing: Kirigami.Units.mediumSpacing
+
+            Controls.Label {
+                text: i18nc("@label", "Grid arrangement:")
+                opacity: 0.7
+            }
+
+            Repeater {
+                model: ListModel {
+                    ListElement { modeValue: "horizontal"; modeLabel: "3×1 Horizontal" }
+                    ListElement { modeValue: "grid-2x2"; modeLabel: "2×2 Grid" }
+                    ListElement { modeValue: "left-right"; modeLabel: "Left + Right" }
+                }
+
+                Controls.Button {
+                    text: model.modeLabel
+                    flat: true
+                    checked: root.gridSubLayout === model.modeValue
+                    checkable: true
+
+                    onClicked: root.gridSubLayout = model.modeValue
+
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: -Kirigami.Units.smallSpacing
+                        color: "transparent"
+                        border.width: parent.checked ? 2 : 0
+                        border.color: Kirigami.Theme.highlightColor
+                        radius: Kirigami.Units.smallSpacing
+                    }
+                }
             }
         }
 
@@ -856,23 +911,85 @@ Kirigami.ScrollablePage {
 
     Component {
         id: gridLayout
-        GridLayout {
-            columns: 2
-            rows: 2
-            rowSpacing: 2
-            columnSpacing: 2
-            Repeater {
-                model: Math.min(root.instanceCount, 4)
+        Item {
+            anchors.fill: parent
+
+            readonly property bool isLeftRight: root.instanceCount === 3 && root.gridSubLayout === "left-right"
+
+            readonly property int effectiveCols: {
+                if (isLeftRight) return 2;
+                if (root.instanceCount <= 2) return root.instanceCount;
+                if (root.instanceCount === 3) {
+                    return root.gridSubLayout === "grid-2x2" ? 2 : 3;
+                }
+                return 2;
+            }
+            readonly property int effectiveRows: {
+                if (isLeftRight) return 2;
+                if (root.instanceCount <= 2) return 1;
+                if (root.instanceCount === 3) {
+                    return root.gridSubLayout === "grid-2x2" ? 2 : 1;
+                }
+                return 2;
+            }
+
+            GridLayout {
+                anchors.fill: parent
+                columns: parent.effectiveCols
+                rowSpacing: 2
+                columnSpacing: 2
+                visible: !parent.isLeftRight
+                Repeater {
+                    model: root.instanceCount
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        color: index === 0 ? Kirigami.Theme.highlightColor : Kirigami.Theme.positiveBackgroundColor
+                        opacity: 0.5
+                        radius: 2
+                        Controls.Label {
+                            anchors.centerIn: parent
+                            text: (index + 1).toString()
+                            font.bold: true
+                        }
+                    }
+                }
+            }
+
+            Row {
+                anchors.fill: parent
+                spacing: 2
+                visible: parent.isLeftRight
                 Rectangle {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    color: index === 0 ? Kirigami.Theme.highlightColor : Kirigami.Theme.positiveBackgroundColor
+                    width: parent.width * 2 / 5
+                    height: parent.height
+                    color: Kirigami.Theme.highlightColor
                     opacity: 0.5
                     radius: 2
                     Controls.Label {
                         anchors.centerIn: parent
-                        text: (index + 1).toString()
+                        text: "1"
                         font.bold: true
+                    }
+                }
+                Column {
+                    width: parent.width * 3 / 5 - 2
+                    height: parent.height
+                    spacing: 2
+                    Repeater {
+                        model: 2
+                        Rectangle {
+                            width: parent.width
+                            height: (parent.parent.height - 2) / 2
+                            color: Kirigami.Theme.positiveBackgroundColor
+                            opacity: 0.5
+                            radius: 2
+                            Controls.Label {
+                                anchors.centerIn: parent
+                                text: (index + 2).toString()
+                                font.bold: true
+                            }
+                        }
                     }
                 }
             }

--- a/src/qml/pages/SessionSetupPage.qml
+++ b/src/qml/pages/SessionSetupPage.qml
@@ -21,7 +21,6 @@ Kirigami.ScrollablePage {
     required property var userManager
     required property var presetManager
 
-    // Sync with session manager
     property int instanceCount: sessionManager ? sessionManager.instanceCount : 2
     property string layoutMode: sessionManager ? sessionManager.currentLayout : "horizontal"
     property string gridSubLayout: sessionManager ? sessionManager.currentGridSubLayout : ""
@@ -61,7 +60,6 @@ Kirigami.ScrollablePage {
         return [{ username: "" }].concat(filtered)
     }
 
-    // Helper function to get primary monitor size
     function getPrimaryMonitorSize() {
         if (!monitorManager) return { width: 1920, height: 1080 }
         let monitors = monitorManager.monitors
@@ -70,7 +68,6 @@ Kirigami.ScrollablePage {
                 return { width: monitors[i].width, height: monitors[i].height }
             }
         }
-        // Fallback to first monitor or default
         if (monitors.length > 0) {
             return { width: monitors[0].width, height: monitors[0].height }
         }
@@ -80,7 +77,6 @@ Kirigami.ScrollablePage {
     onLayoutModeChanged: {
         if (sessionManager) {
             sessionManager.currentLayout = layoutMode
-            // Recalculate output resolutions based on screen size
             let screenSize = getPrimaryMonitorSize()
             sessionManager.recalculateOutputResolutions(screenSize.width, screenSize.height)
         }
@@ -97,7 +93,6 @@ Kirigami.ScrollablePage {
     onInstanceCountChanged: {
         if (sessionManager && sessionManager.instanceCount !== instanceCount) {
             sessionManager.instanceCount = instanceCount
-            // Recalculate output resolutions when instance count changes
             let screenSize = getPrimaryMonitorSize()
             sessionManager.recalculateOutputResolutions(screenSize.width, screenSize.height)
         }
@@ -131,7 +126,6 @@ Kirigami.ScrollablePage {
         }
     ]
 
-    // Save profile dialog
     Kirigami.PromptDialog {
         id: saveProfileDialog
         title: i18nc("@title:dialog", "Save Profile")
@@ -164,7 +158,6 @@ Kirigami.ScrollablePage {
     ColumnLayout {
         spacing: Kirigami.Units.largeSpacing
 
-        // Running session status
         Kirigami.InlineMessage {
             Layout.fillWidth: true
             visible: sessionRunner?.running ?? false
@@ -181,7 +174,6 @@ Kirigami.ScrollablePage {
             ]
         }
 
-        // Layout Selection
         Kirigami.Heading {
             text: i18nc("@title", "Screen Layout")
             level: 2
@@ -194,7 +186,6 @@ Kirigami.ScrollablePage {
             opacity: 0.7
         }
 
-        // Player count selector
         RowLayout {
             Layout.fillWidth: true
             spacing: Kirigami.Units.largeSpacing
@@ -217,7 +208,6 @@ Kirigami.ScrollablePage {
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.smallSpacing
 
-            // Horizontal split
             LayoutCard {
                 Layout.fillWidth: true
                 layoutType: "horizontal"
@@ -228,7 +218,6 @@ Kirigami.ScrollablePage {
                 onClicked: layoutMode = "horizontal"
             }
 
-            // Vertical split
             LayoutCard {
                 Layout.fillWidth: true
                 layoutType: "vertical"
@@ -239,7 +228,6 @@ Kirigami.ScrollablePage {
                 onClicked: layoutMode = "vertical"
             }
 
-            // Grid (for 3-4 players)
             LayoutCard {
                 Layout.fillWidth: true
                 layoutType: "grid"
@@ -257,7 +245,6 @@ Kirigami.ScrollablePage {
                 onClicked: layoutMode = "grid"
             }
 
-            // Multi-monitor
             LayoutCard {
                 Layout.fillWidth: true
                 layoutType: "multi-monitor"
@@ -269,7 +256,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Grid sub-layout selector (only visible when grid is selected and 3 players)
         RowLayout {
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.smallSpacing
@@ -309,7 +295,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Instance Configuration
         Kirigami.Heading {
             text: i18nc("@title", "Instance Configuration")
             level: 2
@@ -333,7 +318,6 @@ Kirigami.ScrollablePage {
                 // Copy revision counter for reliable binding
                 property int cardRevision: root?.instancesRevision ?? 0
                 
-                // Current preset ID (updated when instances change)
                 property string currentPresetId: {
                     void(cardRevision)
                     if (!cardSessionManager) return "steam"
@@ -341,7 +325,6 @@ Kirigami.ScrollablePage {
                     return config?.presetId || "steam"
                 }
                 
-                // Overlay patterns for this instance
                 property var overridePatternsModel: {
                     void(cardRevision)
                     if (!cardSessionManager) return []
@@ -394,7 +377,6 @@ Kirigami.ScrollablePage {
                             Kirigami.FormData.label: instanceCard.labelUser
                             Layout.fillWidth: true
 
-                            // Filtered model: excludes users already assigned to other instances
                             model: root.getAvailableUsers(instanceCard.index)
                             textRole: "username"
                             valueRole: "username"
@@ -414,12 +396,10 @@ Kirigami.ScrollablePage {
                                 currentIndex = -1
                             }
 
-                            // Show placeholder when no users available
                             displayText: count === 0
                                 ? i18nc("@info", "No users available")
                                 : (currentIndex >= 0 ? currentText : i18nc("@info", "Select a user..."))
 
-                            // Update session manager when user selects a different user
                             onActivated: {
                                 if (root.sessionManager && currentValue) {
                                     root.sessionManager.setInstanceUser(instanceCard.index, currentValue)
@@ -427,7 +407,6 @@ Kirigami.ScrollablePage {
                             }
                         }
 
-                        // Warning when no user selected
                         Controls.Label {
                             visible: userCombo.currentIndex < 0 && userCombo.count > 0
                             text: i18nc("@info:status", "Please select a user for this instance")
@@ -437,7 +416,6 @@ Kirigami.ScrollablePage {
                             Layout.fillWidth: true
                         }
 
-                        // Launch preset selector
                         Components.PresetSelector {
                             id: presetSelector
                             Kirigami.FormData.label: instanceCard.labelLauncher
@@ -465,7 +443,6 @@ Kirigami.ScrollablePage {
                             opacity: 0.8
                         }
 
-                        // Show assigned devices
                         RowLayout {
                             Kirigami.FormData.label: instanceCard.labelDevices
                             spacing: Kirigami.Units.smallSpacing
@@ -502,7 +479,6 @@ Kirigami.ScrollablePage {
                             wideMode: (root?.width ?? 0) > Kirigami.Units.gridUnit * 30
 
 
-                            // Config file override patterns - each player gets their own copy
                             RowLayout {
                                 Kirigami.FormData.label: instanceCard.labelOverlay
                                 visible: presetSelector.currentPresetId !== ""
@@ -583,7 +559,6 @@ Kirigami.ScrollablePage {
                             }
                         }
 
-                        // Pattern list display (related to Config Overrides)
                         Rectangle {
                             Layout.fillWidth: true
                             Layout.topMargin: Kirigami.Units.smallSpacing
@@ -602,7 +577,6 @@ Kirigami.ScrollablePage {
                                 anchors.margins: Kirigami.Units.largeSpacing
                                 spacing: Kirigami.Units.smallSpacing
 
-                                // Header
                                 RowLayout {
                                     Layout.fillWidth: true
                                     spacing: Kirigami.Units.smallSpacing
@@ -635,7 +609,6 @@ Kirigami.ScrollablePage {
                                     }
                                 }
 
-                                // Pattern items
                                 Repeater {
                                     model: instanceCard.overridePatternsModel
                                     delegate: RowLayout {
@@ -671,7 +644,6 @@ Kirigami.ScrollablePage {
                                     }
                                 }
 
-                                // Help text
                                 Controls.Label {
                                     Layout.fillWidth: true
                                     text: i18nc("@info", "For games that store saves or config in their own folder. Each player gets their own copy of matching files. Place overrides in the preset's override folder.")
@@ -723,7 +695,6 @@ Kirigami.ScrollablePage {
                         }
                     }
 
-                    // Info message when no device is assigned at all
                     Kirigami.InlineMessage {
                         Layout.fillWidth: true
                         visible: {
@@ -732,7 +703,6 @@ Kirigami.ScrollablePage {
                             void(root.devicesRevision)
                             if (!root.deviceManager) return false
 
-                            // Check if any devices are assigned to this instance
                             let assignedPaths = root.deviceManager.getDevicePathsForInstance(instanceCard.index)
                             if (assignedPaths.length > 0) return false
 
@@ -742,7 +712,7 @@ Kirigami.ScrollablePage {
                                 if (pending[i].instanceIndex == instanceCard.index) return false
                             }
 
-                            // No devices assigned and no pending devices
+                            // No devices assigned and no pending devices — show info
                             return true
                         }
                         type: Kirigami.MessageType.Information
@@ -752,7 +722,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Quick actions
         Kirigami.Separator {
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.largeSpacing
@@ -779,7 +748,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Layout card component for visual selection
     component LayoutCard: Kirigami.AbstractCard {
         id: layoutCard
 
@@ -814,7 +782,6 @@ Kirigami.ScrollablePage {
         contentItem: ColumnLayout {
             spacing: Kirigami.Units.smallSpacing
 
-            // Visual representation
             Rectangle {
                 Layout.fillWidth: true
                 Layout.preferredHeight: Kirigami.Units.gridUnit * 4
@@ -829,7 +796,6 @@ Kirigami.ScrollablePage {
                     ColorAnimation { duration: Kirigami.Units.shortDuration }
                 }
 
-                // Dynamic layout visualization
                 Loader {
                     anchors.fill: parent
                     anchors.margins: 2
@@ -864,7 +830,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Layout visualization components
     Component {
         id: horizontalLayout
         RowLayout {

--- a/tests/test_couchplayhelper.cpp
+++ b/tests/test_couchplayhelper.cpp
@@ -13,14 +13,12 @@
 #undef private
 #include "../helper/SystemOps.h"
 
-// Mock SystemOps for testing - no real system calls
 class MockSystemOps : public SystemOps
 {
 public:
     MockSystemOps() = default;
     ~MockSystemOps() override = default;
 
-    // Configuration methods for test setup
     void setAuthResult(bool authorized) { m_authorized = authorized; }
     void setProcessExitCode(int exitCode) { m_processExitCode = exitCode; }
     void setMockProcessStart(bool mock) { m_mockProcessStart = mock; }
@@ -37,7 +35,6 @@ public:
         }
     }
 
-
     void setGroupExists(const QString &groupname, bool exists, gid_t gid = 0, const QStringList &members = {}) {
         if (exists) {
             struct group gr;
@@ -52,7 +49,6 @@ public:
     void setChownResult(int result) { m_chownResult = result; }
     void setChmodResult(int result) { m_chmodResult = result; }
 
-    // Clear all mock data
     void clear() {
         m_pwEntries.clear();
         m_grEntries.clear();
@@ -69,7 +65,6 @@ public:
         m_standardError.clear();
     }
 
-    // Get last process arguments for verification
     QStringList getLastProcessArgs() const { return m_processArgs; }
     QString getLastProcessCommand() const { return m_processCommand; }
 
@@ -79,7 +74,6 @@ public:
     };
     QList<ProcessInvocation> m_processInvocations;
 
-    // User/group lookup operations
     struct passwd *getpwnam(const char *name) override {
         QString username = QString::fromLocal8Bit(name);
         if (m_pwEntries.contains(username)) {
@@ -110,7 +104,6 @@ public:
         return nullptr;
     }
 
-    // Filesystem operations
     bool fileExists(const QString &path) override {
         return m_files.value(path, false);
     }
@@ -121,45 +114,37 @@ public:
 
     bool mkpath(const QString &path) override {
         Q_UNUSED(path)
-        // Always succeed for tests
         return true;
     }
 
     bool removeFile(const QString &path) override {
         Q_UNUSED(path)
-        // Always succeed for tests
         return true;
     }
 
     bool copyFile(const QString &source, const QString &dest) override {
         Q_UNUSED(source)
         Q_UNUSED(dest)
-        // Always succeed for tests
         return true;
     }
 
     bool writeFile(const QString &path, const QByteArray &content) override {
         Q_UNUSED(path)
         Q_UNUSED(content)
-        // Always succeed for tests
         return true;
     }
 
-    // Device path validation
     bool statPath(const QString &path, struct stat *buf) override {
         Q_UNUSED(path)
         Q_UNUSED(buf)
-        // Assume valid for tests
         return true;
     }
 
     bool isCharDevice(mode_t mode) override {
         Q_UNUSED(mode)
-        // Assume valid for tests
         return true;
     }
 
-    // Ownership and permissions
     int chown(const QString &path, uid_t owner, gid_t group) override {
         Q_UNUSED(path)
         Q_UNUSED(owner)
@@ -173,7 +158,6 @@ public:
         return m_chmodResult;
     }
 
-    // Process operations
     QProcess *createProcess(QObject *parent = nullptr) override {
         return new QProcess(parent);
     }
@@ -211,7 +195,6 @@ public:
         return m_standardOutput;
     }
 
-    // Directory listing
     QStringList entryList(const QString &path, const QStringList &nameFilters, QDir::Filters filters) override {
         Q_UNUSED(path)
         Q_UNUSED(nameFilters)
@@ -219,14 +202,12 @@ public:
         return QStringList();
     }
 
-    // Process signaling
     bool killProcess(pid_t pid, int signal) override {
         Q_UNUSED(pid)
         Q_UNUSED(signal)
         return true;
     }
 
-    // Authorization check
     bool checkAuthorization(const QString &action) override {
         Q_UNUSED(action)
         return m_authorized;
@@ -261,7 +242,6 @@ private:
             gr.gr_name = groupBytes.data();
             gr.gr_gid = gid;
 
-            // Build member list
             m_memberPtrs.clear();
             m_memberStrings.clear();
             for (const QString &member : members) {
@@ -292,7 +272,6 @@ private:
     QByteArray m_standardError;
 };
 
-// Test class for CouchPlayHelper
 class TestCouchPlayHelper : public QObject
 {
     Q_OBJECT
@@ -384,26 +363,22 @@ private:
 
 void TestCouchPlayHelper::initTestCase()
 {
-    // Register helper on session bus with unique service name
     m_serviceName = QStringLiteral("io.github.hikaps.CouchPlayHelper.Test");
     m_objectPath = QStringLiteral("/io/github/hikaps/CouchPlayHelper");
 
     m_ops = new MockSystemOps();
     m_ops->clear();
 
-    // Set up default mock data
     m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001, {});
     m_ops->setGroupExists(QStringLiteral("input"), true, 44, {});
 
     m_helper = new CouchPlayHelper(m_ops);
 
-    // Register object on session bus with ExportAllSlots flag
     if (!QDBusConnection::sessionBus().registerObject(m_objectPath, m_helper,
             QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals)) {
         qFatal("Failed to register CouchPlayHelper on session bus");
     }
 
-    // Register service name on session bus
     if (!QDBusConnection::sessionBus().registerService(m_serviceName)) {
         qFatal("Failed to register service name %s on session bus", qUtf8Printable(m_serviceName));
     }
@@ -411,7 +386,6 @@ void TestCouchPlayHelper::initTestCase()
 
 void TestCouchPlayHelper::cleanupTestCase()
 {
-    // Unregister from session bus
     QDBusConnection::sessionBus().unregisterObject(m_objectPath);
     QDBusConnection::sessionBus().unregisterService(m_serviceName);
 
@@ -425,7 +399,6 @@ void TestCouchPlayHelper::cleanupTestCase()
 
 void TestCouchPlayHelper::init()
 {
-    // Create QDBusInterface for each test
     m_dbusInterface = new QDBusInterface(
         m_serviceName,
         m_objectPath,
@@ -444,8 +417,6 @@ void TestCouchPlayHelper::cleanup()
     m_dbusInterface = nullptr;
     m_ops->clear();
 }
-
-// ============ CreateUser Tests ============
 
 void TestCouchPlayHelper::testCreateUserSuccess()
 {
@@ -555,8 +526,6 @@ void TestCouchPlayHelper::testCreateUserLingerFailure()
     QCOMPARE(reply.error().type(), QDBusError::Failed);
 }
 
-// ============ DeleteUser Tests ============
-
 void TestCouchPlayHelper::testDeleteUserSuccess()
 {
     m_ops->clear();
@@ -659,8 +628,6 @@ void TestCouchPlayHelper::testDeleteUserProcessFailure()
     QCOMPARE(reply.error().type(), QDBusError::Failed);
 }
 
-// ============ IsInCouchPlayGroup Tests ============
-
 void TestCouchPlayHelper::testIsInCouchPlayGroupTrue()
 {
     m_ops->clear();
@@ -716,8 +683,6 @@ void TestCouchPlayHelper::testIsInCouchPlayGroupNonexistentGroup()
     QVERIFY(reply.isValid());
     QVERIFY(!reply.value());
 }
-
-// ============ EnableLinger Tests ============
 
 void TestCouchPlayHelper::testEnableLingerSuccess()
 {
@@ -790,8 +755,6 @@ void TestCouchPlayHelper::testEnableLingerProcessFailure()
     QCOMPARE(reply.error().type(), QDBusError::Failed);
 }
 
-// ============ IsLingerEnabled Tests ============
-
 void TestCouchPlayHelper::testIsLingerEnabledTrue()
 {
     m_ops->clear();
@@ -819,8 +782,6 @@ void TestCouchPlayHelper::testIsLingerEnabledFalse()
     QVERIFY(reply.isValid());
     QVERIFY(!reply.value());
 }
-
-// ============ Device Ownership Tests ============
 
 void TestCouchPlayHelper::testChangeDeviceOwnerInvalidPathNotUnderDevInput()
 {
@@ -1232,8 +1193,6 @@ void TestCouchPlayHelper::testChangeDeviceOwnerBatchAllFailure()
     QVERIFY(!reply.isValid());
 }
 
-// ============ Runtime Access Tests (Polkit + D-Bus Integration) ============
-
 void TestCouchPlayHelper::testSetupRuntimeAccessSuccess()
 {
     m_ops->clear();
@@ -1350,8 +1309,6 @@ void TestCouchPlayHelper::testRemoveRuntimeAccessUserNotFound()
     QVERIFY(reply.value());
 }
 
-// ============ Version Test ============
-
 void TestCouchPlayHelper::testVersion()
 {
     m_ops->clear();
@@ -1363,8 +1320,6 @@ void TestCouchPlayHelper::testVersion()
     QVERIFY(reply.isValid());
     QVERIFY(!reply.value().isEmpty());
 }
-
-// ============ Launch/Stop/Kill Instance Tests ============
 
 void TestCouchPlayHelper::testGenerateServiceName()
 {

--- a/tests/test_presetmanager.cpp
+++ b/tests/test_presetmanager.cpp
@@ -26,18 +26,15 @@ private Q_SLOTS:
     void init();
     void cleanup();
 
-    // Builtin presets tests
     void testBuiltinPresetsExist();
     void testGetCommand();
     void testGetWorkingDirectory();
     void testGetLauncherId();
     void testGetSteamIntegration();
 
-    // Custom presets tests
     void testAddCustomPreset();
     void testRemoveCustomPreset();
 
-    // Shared directories tests
     void testGetSetSharedDirectories();
 
 private:
@@ -83,8 +80,6 @@ void TestPresetManager::cleanup()
     QStandardPaths::setTestModeEnabled(false);
 }
 
-// ============ Builtin Presets Tests ============
-
 void TestPresetManager::testBuiltinPresetsExist()
 {
     PresetManager manager;
@@ -92,7 +87,6 @@ void TestPresetManager::testBuiltinPresetsExist()
     QVariantList presets = manager.presetsAsVariant();
     QVERIFY(presets.size() >= 3); // Steam, Heroic, Lutris
 
-    // Check for Steam preset
     bool foundSteam = false;
     bool foundHeroic = false;
     bool foundLutris = false;
@@ -125,15 +119,12 @@ void TestPresetManager::testGetCommand()
 {
     PresetManager manager;
 
-    // Test Steam preset command
     QString steamCommand = manager.getCommand(QStringLiteral("steam"));
     QCOMPARE(steamCommand, QStringLiteral("steam -tenfoot -steamdeck"));
 
-    // Test Heroic preset command
     QString heroicCommand = manager.getCommand(QStringLiteral("heroic"));
     QVERIFY(!heroicCommand.isEmpty());
 
-    // Test Lutris preset command
     QString lutrisCommand = manager.getCommand(QStringLiteral("lutris"));
     QCOMPARE(lutrisCommand, QStringLiteral("lutris"));
 }
@@ -142,7 +133,6 @@ void TestPresetManager::testGetWorkingDirectory()
 {
     PresetManager manager;
 
-    // Builtin presets typically have empty working directories
     QString steamDir = manager.getWorkingDirectory(QStringLiteral("steam"));
     QVERIFY(steamDir.isEmpty());
 
@@ -166,15 +156,11 @@ void TestPresetManager::testGetSteamIntegration()
 {
     PresetManager manager;
 
-    // Steam preset should have integration enabled
     QVERIFY(manager.getSteamIntegration(QStringLiteral("steam")));
 
-    // Heroic and Lutris should have it disabled
     QVERIFY(!manager.getSteamIntegration(QStringLiteral("heroic")));
     QVERIFY(!manager.getSteamIntegration(QStringLiteral("lutris")));
 }
-
-// ============ Custom Presets Tests ============
 
 void TestPresetManager::testAddCustomPreset()
 {
@@ -193,7 +179,6 @@ void TestPresetManager::testAddCustomPreset()
     QVERIFY(id.startsWith(QStringLiteral("custom-")));
     QCOMPARE(presetsChangedSpy.count(), 1);
 
-    // Verify preset was added
     QVariantList presets = manager.presetsAsVariant();
     bool found = false;
     for (const QVariant &presetVar : presets) {
@@ -236,8 +221,6 @@ void TestPresetManager::testRemoveCustomPreset()
         QVERIFY(preset[QStringLiteral("id")] != id);
     }
 }
-
-// ============ Shared Directories Tests ============
 
 void TestPresetManager::testGetSetSharedDirectories()
 {

--- a/tests/test_sessionmanager.cpp
+++ b/tests/test_sessionmanager.cpp
@@ -13,7 +13,6 @@
 
 #include "SessionManager.h"
 
-// Helper macro for QVariantMap key access with proper QString conversion
 #define KEY(x) QStringLiteral(x)
 
 class TestSessionManager : public QObject
@@ -60,7 +59,6 @@ private:
 
 void TestSessionManager::initTestCase()
 {
-    // Create a temporary directory for test profiles
     m_tempDir = new QTemporaryDir();
     QVERIFY(m_tempDir->isValid());
 }
@@ -92,14 +90,11 @@ void TestSessionManager::testInitialization()
 
 void TestSessionManager::testNewSession()
 {
-    // First, set some values
     m_sessionManager->setInstanceCount(3);
     m_sessionManager->setCurrentLayout(QStringLiteral("vertical"));
     
-    // Now start a new session
     m_sessionManager->newSession();
     
-    // Should reset to defaults
     QCOMPARE(m_sessionManager->instanceCount(), 2);
     QCOMPARE(m_sessionManager->currentLayout(), QStringLiteral("horizontal"));
     QVERIFY(m_sessionManager->currentProfileName().isEmpty());
@@ -138,10 +133,7 @@ void TestSessionManager::testCurrentLayout()
 
 void TestSessionManager::testGetInstanceConfig()
 {
-    // Get config for instance 0
     QVariantMap config = m_sessionManager->getInstanceConfig(0);
-    
-    // Should have default values
     QVERIFY(config.contains(KEY("internalWidth")));
     QVERIFY(config.contains(KEY("internalHeight")));
     QVERIFY(config.contains(KEY("refreshRate")));
@@ -197,11 +189,9 @@ void TestSessionManager::testSaveProfile()
 {
     QSignalSpy spy(m_sessionManager, &SessionManager::savedProfilesChanged);
     
-    // Configure session
     m_sessionManager->setInstanceCount(3);
     m_sessionManager->setCurrentLayout(QStringLiteral("grid"));
     
-    // Save profile
     bool result = m_sessionManager->saveProfile(QStringLiteral("TestProfile"));
     QCOMPARE(result, true);
     QCOMPARE(spy.count(), 1);
@@ -212,16 +202,14 @@ void TestSessionManager::testSaveProfile()
 
 void TestSessionManager::testLoadProfile()
 {
-    // First save a profile
     m_sessionManager->setInstanceCount(4);
     m_sessionManager->setCurrentLayout(QStringLiteral("vertical"));
     m_sessionManager->saveProfile(QStringLiteral("LoadTestProfile"));
     
-    // Reset session
+    // Reset session before loading
     m_sessionManager->newSession();
     QCOMPARE(m_sessionManager->instanceCount(), 2);
     
-    // Load the profile
     bool result = m_sessionManager->loadProfile(QStringLiteral("LoadTestProfile"));
     QCOMPARE(result, true);
     QCOMPARE(m_sessionManager->instanceCount(), 4);
@@ -240,7 +228,6 @@ void TestSessionManager::testDeleteProfile()
     
     QSignalSpy spy(m_sessionManager, &SessionManager::savedProfilesChanged);
     
-    // Delete it
     bool result = m_sessionManager->deleteProfile(QStringLiteral("DeleteTestProfile"));
     QCOMPARE(result, true);
     QCOMPARE(spy.count(), 1);
@@ -261,11 +248,9 @@ void TestSessionManager::testSavedProfiles()
         m_sessionManager->deleteProfile(profile.name);
     }
     
-    // Initially should be empty
     profiles = m_sessionManager->savedProfiles();
     int initialCount = profiles.size();
     
-    // Save some profiles
     m_sessionManager->saveProfile(QStringLiteral("Profile1"));
     m_sessionManager->saveProfile(QStringLiteral("Profile2"));
     
@@ -337,23 +322,19 @@ void TestSessionManager::testGetAssignedUsers()
     m_sessionManager->newSession();
     m_sessionManager->setInstanceCount(3);
     
-    // Set users for instances
     m_sessionManager->setInstanceUser(0, QString());  // Primary user (empty string)
     m_sessionManager->setInstanceUser(1, QStringLiteral("player2"));
     m_sessionManager->setInstanceUser(2, QStringLiteral("player3"));
     
-    // Get assigned users excluding index 0 - should return player2 and player3
     QStringList assigned = m_sessionManager->getAssignedUsers(0);
     QCOMPARE(assigned.size(), 2);
     QVERIFY(assigned.contains(QStringLiteral("player2")));
     QVERIFY(assigned.contains(QStringLiteral("player3")));
     
-    // Get assigned users excluding index 1 - should return only player3
     assigned = m_sessionManager->getAssignedUsers(1);
     QCOMPARE(assigned.size(), 1);
     QVERIFY(assigned.contains(QStringLiteral("player3")));
     
-    // Get assigned users excluding index 2 - should return only player2
     assigned = m_sessionManager->getAssignedUsers(2);
     QCOMPARE(assigned.size(), 1);
     QVERIFY(assigned.contains(QStringLiteral("player2")));


### PR DESCRIPTION
## Summary

- Add configurable grid sub-layouts for 3-player sessions: 3×1 horizontal (default), 2×2 with gap, and left+right (40/60) split
- Refactor instance launching from parallel to sequential to fix window positioning race conditions with KWin
- Add visual layout previews that adapt to selected sub-layout
- Stop session on window positioning timeout instead of continuing broken
- Clean up stale `--position` TODO in GamescopeInstance