### PR TITLE
refactor: code cleanup and screensaver inhibition

### DIFF
--- a/helper/CouchPlayHelper.cpp
+++ b/helper/CouchPlayHelper.cpp
@@ -218,7 +218,6 @@ bool CouchPlayHelper::ChangeDeviceOwner(const QString &devicePath, uint uid)
         return false;
     }
 
-    // Set permissions to 0600 (owner read/write only) for input isolation
     if (m_ops->chown(devicePath, uid, pw->pw_gid) != 0) {
         sendErrorReply(QDBusError::Failed,
             QStringLiteral("Failed to change ownership of %1: %2")
@@ -226,8 +225,7 @@ bool CouchPlayHelper::ChangeDeviceOwner(const QString &devicePath, uint uid)
         return false;
     }
 
-    // Set permissions to 0600 (owner read/write only) for input isolation
-    // This ensures only the assigned user can read the device, not the group
+    // Only the assigned user can read the device, not the group
     if (m_ops->chmod(devicePath, 0600) != 0) {
         sendErrorReply(QDBusError::Failed,
             QStringLiteral("Failed to set permissions on %1: %2")
@@ -279,7 +277,6 @@ bool CouchPlayHelper::ResetDeviceOwner(const QString &devicePath)
         return false;
     }
 
-    // Restore permissions to 0660 (owner and group read/write)
     if (m_ops->chmod(devicePath, 0660) != 0) {
         sendErrorReply(QDBusError::Failed,
             QStringLiteral("Failed to reset permissions on %1").arg(devicePath));
@@ -300,8 +297,7 @@ int CouchPlayHelper::ResetAllDevices()
     gid_t inputGid = inputGroup ? inputGroup->gr_gid : 0;
 
     for (const QString &path : devices) {
-    // Restore to root:input with 0660 permissions
-    if (m_ops->chown(path, 0, inputGid) == 0 &&
+        if (m_ops->chown(path, 0, inputGid) == 0 &&
             m_ops->chmod(path, 0660) == 0) {
             successCount++;
             m_modifiedDevices.removeAll(path);
@@ -336,11 +332,9 @@ uint CouchPlayHelper::CreateUser(const QString &username, const QString &fullNam
     // -f flag means no error if group exists, so we don't check exit code
     runCommand(QStringLiteral("groupadd"), {QStringLiteral("-f"), COUCHPLAY_GROUP});
 
-    // Create user with useradd
     QProcess *process = m_ops->createProcess();
     QStringList args;
-    args << QStringLiteral("-m")  // Create home directory
-         << QStringLiteral("-c") << fullName
+    args << QStringLiteral("-m") << QStringLiteral("-c") << fullName
          << QStringLiteral("-s") << QStringLiteral("/bin/bash");
 
     args << QStringLiteral("-G") << QStringLiteral("input,") + COUCHPLAY_GROUP;
@@ -435,7 +429,6 @@ bool CouchPlayHelper::validateUserPath(const QString &path, const QString &usern
 
 bool CouchPlayHelper::IsInCouchPlayGroup(const QString &username)
 {
-    // Get the couchplay group
     struct group *grp = m_ops->getgrnam(COUCHPLAY_GROUP.toLocal8Bit().constData());
     if (!grp) {
         return false;
@@ -755,7 +748,6 @@ bool CouchPlayHelper::runCommand(const QString &program, const QStringList &args
 
 bool CouchPlayHelper::isValidDevicePath(const QString &path)
 {
-    // Check for path traversal
     if (path.contains(QStringLiteral(".."))) {
         return false;
     }
@@ -1605,7 +1597,6 @@ QString CouchPlayHelper::GetUserSteamId(const QString &username)
         return QString();
     }
 
-    // Check for Steam userdata in common locations
     QStringList possibleRoots = {
         userHome + QStringLiteral("/.steam/steam/userdata"),
         userHome + QStringLiteral("/.local/share/Steam/userdata"),
@@ -1616,7 +1607,6 @@ QString CouchPlayHelper::GetUserSteamId(const QString &username)
             continue;
         }
 
-        // Find first numeric directory (Steam user ID)
         QStringList entries = m_ops->entryList(userDataBase, QStringList(), QDir::Dirs | QDir::NoDotAndDotDot);
         for (const QString &entry : entries) {
             bool ok;

--- a/helper/CouchPlayHelper.h
+++ b/helper/CouchPlayHelper.h
@@ -14,7 +14,6 @@
 
 #include "SystemOps.h"
 
-// Forward declaration
 class UnitMonitor;
 
 /**

--- a/src/core/GamescopeInstance.cpp
+++ b/src/core/GamescopeInstance.cpp
@@ -215,13 +215,11 @@ QStringList GamescopeInstance::buildGamescopeArgs(const QVariantMap &config)
     // Note: Don't pass --backend flag - let gamescope auto-detect
     // It will use wayland backend when WAYLAND_DISPLAY is set
 
-    // Internal resolution (game renders at this)
     int internalW = config.value(QStringLiteral("internalWidth"), 1920).toInt();
     int internalH = config.value(QStringLiteral("internalHeight"), 1080).toInt();
     args << QStringLiteral("-w") << QString::number(internalW);
     args << QStringLiteral("-h") << QString::number(internalH);
 
-    // Output resolution (window size)
     int outputW = config.value(QStringLiteral("outputWidth"), 960).toInt();
     int outputH = config.value(QStringLiteral("outputHeight"), 1080).toInt();
     args << QStringLiteral("-W") << QString::number(outputW);

--- a/src/core/PresetManager.cpp
+++ b/src/core/PresetManager.cpp
@@ -58,10 +58,9 @@ QStringList PresetManager::getDefaultSharedDirectories(const QString &id) const
         }
     } else if (id == QStringLiteral("heroic")) {
         if (m_heroicConfigManager && m_heroicConfigManager->isHeroicDetected()) {
-            // NOTE: configPath is NOT added to shared directories because:
-            // 1. syncConfigToUser() copies specific config files to the gaming user's home
-            // 2. Bind-mounting the config dir would cause ownership conflicts when syncing
-            // Only share the install path where games are installed
+            // Don't share configPath: syncConfigToUser() copies specific config files to the gaming user's home,
+            // and bind-mounting the config dir would cause ownership conflicts when syncing.
+            // Only share the install path where games are installed.
             QString installPath = m_heroicConfigManager->defaultInstallPath();
             if (!installPath.isEmpty()) {
                 dirs.append(installPath);
@@ -410,7 +409,6 @@ LaunchPreset PresetManager::parseDesktopFile(const QString &filePath) const
         return preset;
     }
 
-    // Use QSettings to parse INI-like .desktop format
     QSettings desktop(filePath, QSettings::IniFormat);
     desktop.beginGroup(QStringLiteral("Desktop Entry"));
 
@@ -430,7 +428,6 @@ LaunchPreset PresetManager::parseDesktopFile(const QString &filePath) const
     preset.iconName = desktop.value(QStringLiteral("Icon")).toString();
     preset.desktopFilePath = filePath;
 
-    // Check Categories for Game - could filter to only games in the future
     // QString categories = desktop.value(QStringLiteral("Categories")).toString();
 
     return preset;
@@ -440,16 +437,14 @@ QString PresetManager::cleanExecCommand(const QString &exec)
 {
     QString cleaned = exec;
 
-    // Remove freedesktop field codes
-    // These are placeholders for file arguments, URLs, etc.
     static const QStringList fieldCodes = {
-        QStringLiteral("%f"), QStringLiteral("%F"),  // File(s)
-        QStringLiteral("%u"), QStringLiteral("%U"),  // URL(s)
-        QStringLiteral("%d"), QStringLiteral("%D"),  // Directory (deprecated)
-        QStringLiteral("%n"), QStringLiteral("%N"),  // Filename (deprecated)
-        QStringLiteral("%i"),                         // Icon
-        QStringLiteral("%c"),                         // Translated name
-        QStringLiteral("%k")                          // Desktop file path
+        QStringLiteral("%f"), QStringLiteral("%F"),
+        QStringLiteral("%u"), QStringLiteral("%U"),
+        QStringLiteral("%d"), QStringLiteral("%D"),
+        QStringLiteral("%n"), QStringLiteral("%N"),
+        QStringLiteral("%i"),
+        QStringLiteral("%c"),
+        QStringLiteral("%k")
     };
 
     for (const QString &code : fieldCodes) {

--- a/src/core/PresetManager.h
+++ b/src/core/PresetManager.h
@@ -13,9 +13,6 @@
 #include "HeroicConfigManager.h"
 #include "SteamConfigManager.h"
 
-/**
- * LauncherInfo - Launcher-specific configuration and paths
- */
 struct LauncherInfo {
     Q_GADGET
     Q_PROPERTY(QString configPath MEMBER configPath)
@@ -25,11 +22,11 @@ struct LauncherInfo {
     Q_PROPERTY(bool hasShortcutSync MEMBER hasShortcutSync)
 
 public:
-    QString configPath;           // Main config directory
-    QString dataPath;             // Game data/library path
+    QString configPath;
+    QString dataPath;
     QStringList gameDirectories;  // Paths needing ACLs (computed at runtime)
-    bool requiresAcls = false;    // Does this launcher need ACL setup?
-    bool hasShortcutSync = false; // Can we sync shortcuts from this launcher?
+    bool requiresAcls = false;
+    bool hasShortcutSync = false;
     
     bool operator==(const LauncherInfo &other) const {
         return configPath == other.configPath && 
@@ -41,9 +38,6 @@ public:
 
 Q_DECLARE_METATYPE(LauncherInfo)
 
-/**
- * @brief A launch preset defining how to start a game/application
- */
 struct LaunchPreset {
     Q_GADGET
     Q_PROPERTY(QString id MEMBER id)
@@ -60,16 +54,15 @@ struct LaunchPreset {
     Q_PROPERTY(QStringList sharedDirectories MEMBER sharedDirectories)
 
 public:
-    QString id;                     // Unique ID (e.g., "steam", "heroic", "lutris", "custom-abc123")
-    QString name;                   // Display name
-    QString command;                // Launch command
-    QString workingDirectory;       // Optional working dir (from .desktop Path=)
-    QString iconName;               // Icon name for UI
+    QString id;                     // e.g., "steam", "heroic", "lutris", "custom-abc123"
+    QString name;
+    QString command;
+    QString workingDirectory;       // Optional, from .desktop Path=
+    QString iconName;
     QString desktopFilePath;        // Source .desktop file (if applicable)
     bool isBuiltin = false;         // true for Steam/Heroic/Lutris
     bool steamIntegration = false;  // Enable gamescope -e flag
     
-    // Launcher-aware fields
     QString launcherId;             // "steam", "heroic", "lutris", "custom" (empty for non-launcher presets)
     LauncherInfo launcherInfo;      // Populated by detection for launcher presets
     QStringList sharedDirectories;  // Per-preset shared directories for ACL/mount setup
@@ -97,62 +90,25 @@ public:
     explicit PresetManager(QObject *parent = nullptr);
     ~PresetManager() override;
 
-    /**
-     * @brief Set the HeroicConfigManager for Heroic integration
-     */
     Q_INVOKABLE void setHeroicConfigManager(HeroicConfigManager *manager);
-    
-    /**
-     * @brief Get the HeroicConfigManager
-     */
     HeroicConfigManager *heroicConfigManager() const { return m_heroicConfigManager; }
 
-    /**
-     * @brief Set the SteamConfigManager for Steam library detection
-     */
     Q_INVOKABLE void setSteamConfigManager(SteamConfigManager *manager);
-
-    /**
-     * @brief Get the SteamConfigManager
-     */
     SteamConfigManager *steamConfigManager() const { return m_steamConfigManager; }
 
-    /**
-     * @brief Get all available presets (builtin + custom)
-     */
     QList<LaunchPreset> presets() const;
     QVariantList presetsAsVariant() const;
 
     /**
-     * @brief Get applications discovered from .desktop files
-     * These are potential presets that can be added as custom presets
+     * @brief Applications discovered from .desktop files, available as potential custom presets
      */
     QList<LaunchPreset> availableApplications() const { return m_availableApplications; }
     QVariantList availableApplicationsAsVariant() const;
 
-    /**
-     * @brief Get a preset by ID
-     */
     Q_INVOKABLE LaunchPreset getPreset(const QString &id) const;
-
-    /**
-     * @brief Get the command for a preset
-     */
     Q_INVOKABLE QString getCommand(const QString &id) const;
-
-    /**
-     * @brief Get the working directory for a preset
-     */
     Q_INVOKABLE QString getWorkingDirectory(const QString &id) const;
-
-    /**
-     * @brief Check if a preset has Steam integration enabled
-     */
     Q_INVOKABLE bool getSteamIntegration(const QString &id) const;
-
-    /**
-     * @brief Get launcher ID for a preset
-     */
     Q_INVOKABLE QString getLauncherId(const QString &id) const;
 
     /**
@@ -160,14 +116,7 @@ public:
      */
     Q_INVOKABLE QStringList getGameDirectories(const QString &id) const;
 
-    /**
-     * @brief Get shared directories for a preset
-     */
     Q_INVOKABLE QStringList getSharedDirectories(const QString &id) const;
-
-    /**
-     * @brief Set shared directories for a preset
-     */
     Q_INVOKABLE bool setSharedDirectories(const QString &id, const QStringList &directories);
 
     /**
@@ -252,9 +201,6 @@ private:
      */
     LaunchPreset parseDesktopFile(const QString &filePath) const;
 
-    /**
-     * @brief Generate a unique ID for a custom preset
-     */
     static QString generateCustomId();
 
     /**

--- a/src/core/SessionRunner.cpp
+++ b/src/core/SessionRunner.cpp
@@ -12,6 +12,9 @@
 #include "../dbus/CouchPlayHelperClient.h"
 
 #include <QAction>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
 #include <QDebug>
 #include <QDir>
 #include <QDirIterator>
@@ -94,7 +97,6 @@ void SessionRunner::setSessionManager(SessionManager *manager)
 void SessionRunner::setDeviceManager(DeviceManager *manager)
 {
     if (m_deviceManager != manager) {
-        // Disconnect from old manager
         if (m_deviceManager) {
             disconnect(m_deviceManager, &DeviceManager::deviceReconnected,
                       this, &SessionRunner::onDeviceReconnected);
@@ -209,7 +211,8 @@ bool SessionRunner::start()
         }
     }
 
-    // Calculate window layouts
+    inhibitScreenSaver();
+
     QRect screenGeometry = getScreenGeometry();
     m_layouts = calculateLayout(profile.layout, instanceCount, screenGeometry, profile.gridSubLayout);
 
@@ -280,7 +283,6 @@ bool SessionRunner::start()
         m_pendingInstanceConfigs.append(config);
     }
 
-    // Start instances sequentially to ensure correct window positioning order
     m_nextInstanceToStart = 0;
     startNextInstance();
 
@@ -302,6 +304,8 @@ void SessionRunner::stop()
     }
 
     setStatus(QStringLiteral("Stopping session..."));
+
+    uninhibitScreenSaver();
 
     m_virtualDeviceWatcher->stopWatching();
 
@@ -772,7 +776,6 @@ QRect SessionRunner::getScreenGeometry() const
         return screen->geometry();
     }
 
-    // Fallback: headless or no screen available
     return QRect(0, 0, 1920, 1080);
 }
 
@@ -955,6 +958,7 @@ void SessionRunner::onInstanceStopped()
         Q_EMIT runningInstanceCountChanged();
 
         if (!isRunning()) {
+            uninhibitScreenSaver();
             setStatus(QStringLiteral("Session ended"));
             restoreDeviceOwnership();
             Q_EMIT runningChanged();
@@ -1227,4 +1231,57 @@ void SessionRunner::onVirtualDeviceAppeared(int eventNumber, const QString &devi
     } else {
         qWarning() << "SessionRunner: Failed to set virtual device ownership" << devicePath;
     }
+}
+
+void SessionRunner::inhibitScreenSaver()
+{
+    if (m_screenSaverCookie != 0) {
+        return;
+    }
+
+    QDBusInterface screenSaver(
+        QStringLiteral("org.freedesktop.ScreenSaver"),
+        QStringLiteral("/org/freedesktop/ScreenSaver"),
+        QStringLiteral("org.freedesktop.ScreenSaver"),
+        QDBusConnection::sessionBus()
+    );
+
+    if (!screenSaver.isValid()) {
+        qCDebug(couchplayCore) << "ScreenSaver D-Bus interface not available, skipping inhibition";
+        return;
+    }
+
+    QDBusReply<uint> reply = screenSaver.call(
+        QStringLiteral("Inhibit"),
+        QStringLiteral("io.github.hikaps.couchplay"),
+        QStringLiteral("Split-screen gaming session active")
+    );
+
+    if (reply.isValid()) {
+        m_screenSaverCookie = reply.value();
+        qCDebug(couchplayCore) << "ScreenSaver inhibited, cookie:" << m_screenSaverCookie;
+    } else {
+        qCWarning(couchplayCore) << "Failed to inhibit ScreenSaver:" << reply.error().message();
+    }
+}
+
+void SessionRunner::uninhibitScreenSaver()
+{
+    if (m_screenSaverCookie == 0) {
+        return;
+    }
+
+    QDBusInterface screenSaver(
+        QStringLiteral("org.freedesktop.ScreenSaver"),
+        QStringLiteral("/org/freedesktop/ScreenSaver"),
+        QStringLiteral("org.freedesktop.ScreenSaver"),
+        QDBusConnection::sessionBus()
+    );
+
+    if (screenSaver.isValid()) {
+        screenSaver.call(QStringLiteral("UnInhibit"), m_screenSaverCookie);
+        qCDebug(couchplayCore) << "ScreenSaver uninhibited, cookie:" << m_screenSaverCookie;
+    }
+
+    m_screenSaverCookie = 0;
 }

--- a/src/core/SessionRunner.h
+++ b/src/core/SessionRunner.h
@@ -30,12 +30,6 @@ class PresetManager;
  * SessionRunner manages the lifecycle of multiple GamescopeInstance objects,
  * handles window layout calculations, device ownership transfers, and
  * coordinates with the SessionManager for configuration.
- * 
- * Typical usage:
- * 1. Set sessionManager, deviceManager, helperClient
- * 2. Call start() to begin the session
- * 3. Monitor via runningInstances property
- * 4. Call stop() to end the session
  */
 class SessionRunner : public QObject
 {
@@ -182,8 +176,11 @@ private:
     void positionInstanceWindow(GamescopeInstance *instance);
     void setupGlobalShortcut();
     void cleanupOverrideDirs(const QStringList &overridePaths);
+    void inhibitScreenSaver();
+    void uninhibitScreenSaver();
 
     QMap<int, QStringList> m_instanceBindPaths;
+    uint m_screenSaverCookie = 0;
 
     // Steam process discovery helpers
     qint64 findSteamProcess(qint64 gamescopePid, int maxDepth = 6) const;

--- a/src/core/WindowManager.cpp
+++ b/src/core/WindowManager.cpp
@@ -108,13 +108,8 @@ QStringList WindowManager::findAllGamescopeWindows()
         return results;
     }
     
-    // Parse the reply - it's an array of structs: a(sssuda{sv})
-    // Each struct: (id, caption, iconName, relevance, score, properties)
-    // The id format is "0_{uuid}" - we need to extract the uuid and check if it's gamescope
-    // 
-    // The properties dict contains complex types (like icon-data with struct (iiibiiay))
-    // that can cause issues with QDBusArgument parsing. We only need the matchId,
-    // so we extract just what we need and skip the rest.
+    // The properties dict contains complex types (e.g. icon-data with struct (iiibiiay))
+    // that break QDBusArgument parsing. We only need matchId, so skip the rest.
     const QDBusArgument arg = reply.arguments().at(0).value<QDBusArgument>();
     
     if (arg.currentType() != QDBusArgument::ArrayType) {
@@ -135,14 +130,11 @@ QStringList WindowManager::findAllGamescopeWindows()
         
         arg >> matchId >> caption >> iconName >> relevance >> score;
         
-        // Skip the properties dict - it contains complex types that are hard to parse
-        // We use QVariant to consume it without fully deserializing
         QVariant propertiesVariant;
         arg >> propertiesVariant;
         
         arg.endStructure();
         
-        // matchId format is "0_{uuid}" - extract the uuid
         if (matchId.contains(QLatin1Char('{'))) {
             QString uuid = matchId.mid(matchId.indexOf(QLatin1Char('{')));
             
@@ -314,7 +306,7 @@ void WindowManager::checkForNewWindows()
     
     QStringList currentWindows = findAllGamescopeWindows();
     
-    // Process pending requests in order (FIFO) — we may remove elements during iteration
+    // FIFO order — elements removed during iteration
     int i = 0;
     while (i < m_pendingRequests.size() && !currentWindows.isEmpty()) {
         const PositionRequest &request = m_pendingRequests[i];
@@ -346,7 +338,6 @@ void WindowManager::checkForNewWindows()
             } else {
                 Q_EMIT positioningTimedOut(requestId);
             }
-            
             // Don't increment i since we removed the current element
         } else {
             ++i;
@@ -386,13 +377,9 @@ bool WindowManager::executePositionScript(const QString &windowId, const QRect &
     for (var i = 0; i < windows.length; i++) {
         var win = windows[i];
         if (win.internalId.toString() === targetUuid) {
-            // Set the frame geometry using a plain JavaScript object
             win.frameGeometry = {x: targetX, y: targetY, width: targetW, height: targetH};
-            // Remove decorations for cleaner positioning
             win.noBorder = true;
-            // Keep above other windows (including panels) for immersive gaming
             win.keepAbove = true;
-            // Hide from taskbar/pager but keep in Alt+Tab for emergency access
             win.skipTaskbar = true;
             win.skipPager = true;
             break;

--- a/src/qml/pages/HomePage.qml
+++ b/src/qml/pages/HomePage.qml
@@ -14,17 +14,15 @@ Kirigami.ScrollablePage {
 
     title: i18nc("@title", "Home")
 
-    // Backend managers (from Main.qml)
     required property var sessionManager
     required property var sessionRunner
     required property var deviceManager
     required property var helperClient
 
-    // Computed properties to avoid repeating conditions
+    // Computed properties
     property bool helperAvailable: helperClient?.available ?? false
     property bool hasControllers: deviceManager && deviceManager.controllers.length > 0
 
-    // Refresh on page load
     Component.onCompleted: {
         if (sessionManager) {
             sessionManager.refreshProfiles()
@@ -61,7 +59,6 @@ Kirigami.ScrollablePage {
                     }
                 }
 
-                // Session status indicator
                 Kirigami.Chip {
                     visible: sessionRunner?.running ?? false
                     text: i18nc("@info", "%1 instances running", sessionRunner ? sessionRunner.runningInstanceCount : 0)
@@ -76,7 +73,6 @@ Kirigami.ScrollablePage {
     ColumnLayout {
         spacing: Kirigami.Units.largeSpacing
 
-        // Active session banner
         Kirigami.InlineMessage {
             Layout.fillWidth: true
             visible: sessionRunner?.running ?? false
@@ -97,7 +93,6 @@ Kirigami.ScrollablePage {
             ]
         }
 
-        // Quick Actions
         Kirigami.Heading {
             text: i18nc("@title", "Quick Actions")
             level: 2
@@ -137,14 +132,12 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Recent Profiles
         Kirigami.Heading {
             text: i18nc("@title", "Recent Profiles")
             level: 2
             Layout.topMargin: Kirigami.Units.largeSpacing
         }
 
-        // Show recent profiles or placeholder
         GridLayout {
             Layout.fillWidth: true
             columns: Math.max(1, Math.floor(root.width / (Kirigami.Units.gridUnit * 16)))
@@ -153,7 +146,6 @@ Kirigami.ScrollablePage {
             visible: (sessionManager?.savedProfiles?.length ?? 0) > 0
 
             Repeater {
-                // Show up to 4 recent profiles
                 model: sessionManager ? sessionManager.savedProfiles.slice(0, 4) : []
 
                 delegate: Kirigami.AbstractCard {
@@ -213,7 +205,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Empty state for profiles
         Kirigami.PlaceholderMessage {
             visible: !sessionManager || sessionManager.savedProfiles.length === 0
             text: i18nc("@info", "No profiles yet")
@@ -230,7 +221,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // View all profiles link
         Controls.Button {
             visible: (sessionManager?.savedProfiles?.length ?? 0) > 4
             text: i18nc("@action:button", "View all %1 profiles...", sessionManager ? sessionManager.savedProfiles.length : 0)
@@ -241,7 +231,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // System Status
         Kirigami.Heading {
             text: i18nc("@title", "System Status")
             level: 2
@@ -331,7 +320,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // System check properties - check if executables exist in PATH
     property bool gamescopeAvailable: Platform.StandardPaths.findExecutable("gamescope") !== ""
     property bool steamAvailable: Platform.StandardPaths.findExecutable("steam") !== ""
 }

--- a/src/qml/pages/SessionSetupPage.qml
+++ b/src/qml/pages/SessionSetupPage.qml
@@ -13,7 +13,6 @@ Kirigami.ScrollablePage {
 
     title: i18nc("@title", "New Session")
 
-    // References to backend managers (from Main.qml)
     required property var sessionManager
     required property var sessionRunner
     required property var deviceManager
@@ -25,10 +24,7 @@ Kirigami.ScrollablePage {
     property string layoutMode: sessionManager ? sessionManager.currentLayout : "horizontal"
     property string gridSubLayout: sessionManager ? sessionManager.currentGridSubLayout : ""
 
-    // Revision counter to force re-evaluation of user filtering when instances change
     property int instancesRevision: 0
-    
-    // Revision counter to force re-evaluation of device display when devices change
     property int devicesRevision: 0
 
     Connections {
@@ -48,7 +44,7 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Get available users for a specific instance (excludes users assigned to other instances)
+    // Get available users for a specific instance
     function getAvailableUsers(forIndex) {
         // Reference instancesRevision to create binding dependency
         void(root.instancesRevision)
@@ -315,7 +311,6 @@ Kirigami.ScrollablePage {
                 property var cardPresetManager: root.presetManager
                 property var cardSessionManager: root.sessionManager
                 
-                // Copy revision counter for reliable binding
                 property int cardRevision: root?.instancesRevision ?? 0
                 
                 property string currentPresetId: {
@@ -381,7 +376,6 @@ Kirigami.ScrollablePage {
                             textRole: "username"
                             valueRole: "username"
 
-                            // Restore selection after model changes
                             onModelChanged: {
                                 let config = root.sessionManager?.getInstanceConfig(instanceCard.index)
                                 let currentUsername = config?.username ?? ""
@@ -427,7 +421,6 @@ Kirigami.ScrollablePage {
                                 if (instanceCard.cardSessionManager) {
                                     instanceCard.cardSessionManager.setInstancePreset(instanceCard.index, presetId)
 
-                                    // Also copy shared directories from the preset
                                     if (instanceCard.cardPresetManager) {
                                         let directories = instanceCard.cardPresetManager.getSharedDirectories(presetId) || []
                                         instanceCard.cardSessionManager.setInstanceSharedDirectories(instanceCard.index, directories)
@@ -662,31 +655,29 @@ Kirigami.ScrollablePage {
                         }
                     }
 
-                    // Warning for missing devices (from loaded profile)
+                    // Warning for missing devices
                     Kirigami.InlineMessage {
                         Layout.fillWidth: true
                         visible: {
-                            // Null-safe check and reference devicesRevision to force re-evaluation
                             if (!root) return false
                             void(root.devicesRevision)
                             if (!root.deviceManager) return false
                             let pending = root.deviceManager.pendingDevices
                             for (let i = 0; i < pending.length; i++) {
-                                // Use == for type-safe comparison (QVariant may convert int to different JS type)
+                                // QVariant may convert int to different JS type
                                 if (pending[i].instanceIndex == instanceCard.index) return true
                             }
                             return false
                         }
                         type: Kirigami.MessageType.Warning
                         text: {
-                            // Null-safe check and reference devicesRevision to force re-evaluation
                             if (!root) return ""
                             void(root.devicesRevision)
                             if (!root.deviceManager) return ""
                             let pending = root.deviceManager.pendingDevices
                             let names = []
                             for (let i = 0; i < pending.length; i++) {
-                                // Use == for type-safe comparison (QVariant may convert int to different JS type)
+                                // QVariant may convert int to different JS type
                                 if (pending[i].instanceIndex == instanceCard.index) {
                                     names.push(pending[i].name)
                                 }
@@ -698,7 +689,6 @@ Kirigami.ScrollablePage {
                     Kirigami.InlineMessage {
                         Layout.fillWidth: true
                         visible: {
-                            // Null-safe check and reference devicesRevision to force re-evaluation
                             if (!root) return false
                             void(root.devicesRevision)
                             if (!root.deviceManager) return false
@@ -706,13 +696,12 @@ Kirigami.ScrollablePage {
                             let assignedPaths = root.deviceManager.getDevicePathsForInstance(instanceCard.index)
                             if (assignedPaths.length > 0) return false
 
-                            // Check if there are pending devices for this instance (disconnected warning takes priority)
+                            // Disconnected warning takes priority
                             let pending = root.deviceManager.pendingDevices
                             for (let i = 0; i < pending.length; i++) {
                                 if (pending[i].instanceIndex == instanceCard.index) return false
                             }
 
-                            // No devices assigned and no pending devices — show info
                             return true
                         }
                         type: Kirigami.MessageType.Information
@@ -757,7 +746,6 @@ Kirigami.ScrollablePage {
         required property string description
         required property int instanceCount
 
-        // Custom animated background for selection feedback
         background: Rectangle {
             color: layoutCard.selected 
                 ? Qt.alpha(Kirigami.Theme.highlightColor, 0.15) 

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -13,39 +13,28 @@ Kirigami.ScrollablePage {
     id: root
     title: i18nc("@title", "Settings")
 
-    // Reference to session runner for settings that affect it
     property var sessionRunner: null
 
-    // Reference to helper client for status display
     required property var helperClient
 
-    // Computed property to avoid repeating condition
     property bool helperAvailable: helperClient?.available ?? false
 
-    // Reference to preset manager (optional, will use internal if not provided)
     property var presetManager: null
 
-    // Reference to steam config manager for shortcut sync
     property var steamConfigManager: null
 
-    // Reference to settings manager for persisted settings
     property var settingsManager: null
 
-    // Reference to heroic config manager for Heroic detection
     property var heroicConfigManager: null
 
-    // Reference to audio manager for audio status
     property var audioManager: null
 
-    // Internal preset manager if not provided externally
     PresetManager {
         id: internalPresetManager
     }
 
-    // Use provided preset manager or internal one
     readonly property var activePresetManager: root.presetManager ?? internalPresetManager
 
-    // Settings convenience properties (bound to SettingsManager)
     readonly property bool hidePanels: settingsManager?.hidePanels ?? true
     readonly property bool killSteam: settingsManager?.killSteam ?? true
     readonly property bool restoreSession: settingsManager?.restoreSession ?? false
@@ -65,7 +54,6 @@ Kirigami.ScrollablePage {
     ColumnLayout {
         spacing: Kirigami.Units.mediumSpacing
 
-        // General Settings Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -109,7 +97,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Gamescope Settings Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -176,7 +163,6 @@ Kirigami.ScrollablePage {
                 Controls.ToolTip.delay: 1000
             }
         }
-        // Launch Presets Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -186,7 +172,6 @@ Kirigami.ScrollablePage {
                 Kirigami.FormData.label: i18nc("@title:group", "Launch Presets")
             }
 
-            // List of current presets and add button
             ColumnLayout {
                 Kirigami.FormData.label: i18nc("@label", "Presets")
                 Layout.fillWidth: true
@@ -257,7 +242,6 @@ Kirigami.ScrollablePage {
                     }
                 }
 
-                // Add preset button
                 Controls.Button {
                     text: i18nc("@action:button", "Add from Application...")
                     icon.name: "list-add"
@@ -268,7 +252,6 @@ Kirigami.ScrollablePage {
                 }
             }
         }
-        // Ignored Devices Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -279,7 +262,6 @@ Kirigami.ScrollablePage {
                 Kirigami.FormData.label: i18nc("@title:group", "Ignored Devices")
             }
 
-            // List of ignored devices
             ColumnLayout {
                 Kirigami.FormData.label: i18nc("@label", "Devices")
                 Layout.fillWidth: true
@@ -322,8 +304,6 @@ Kirigami.ScrollablePage {
                 }
             }
         }
-
-        // Steam Integration Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -381,7 +361,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Heroic Games Launcher Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -455,7 +434,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Game launcher info message
         Kirigami.InlineMessage {
             Layout.fillWidth: true
             visible: (root.steamConfigManager !== null && root.steamConfigManager.steamDetected) 
@@ -465,7 +443,6 @@ Kirigami.ScrollablePage {
         }
 
 
-        // Audio Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -521,7 +498,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Privileged Helper Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -556,7 +532,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Keyboard Shortcuts Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -592,7 +567,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // Helper info card
         Kirigami.InlineMessage {
             Layout.fillWidth: true
             text: i18nc("@info", "The CouchPlay Helper is a privileged system service required for creating users and managing device permissions. It uses PolicyKit for secure authorization.")
@@ -608,7 +582,6 @@ Kirigami.ScrollablePage {
             ]
         }
 
-        // About Section
         Kirigami.FormLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             wideMode: root.width > Kirigami.Units.gridUnit * 30
@@ -656,7 +629,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        // System Requirements Card
         Kirigami.AbstractCard {
             Layout.fillWidth: true
             Layout.bottomMargin: Kirigami.Units.largeSpacing
@@ -672,7 +644,6 @@ Kirigami.ScrollablePage {
                 columnSpacing: Kirigami.Units.largeSpacing
                 rowSpacing: Kirigami.Units.smallSpacing
 
-                // Gamescope - Required
                 RowLayout {
                     spacing: Kirigami.Units.smallSpacing
                     Kirigami.Icon {
@@ -692,7 +663,6 @@ Kirigami.ScrollablePage {
                     Layout.fillWidth: true
                 }
 
-                // PipeWire - Required
                 RowLayout {
                     spacing: Kirigami.Units.smallSpacing
                     Kirigami.Icon {
@@ -712,7 +682,6 @@ Kirigami.ScrollablePage {
                     Layout.fillWidth: true
                 }
 
-                // KDE Plasma - Recommended
                 RowLayout {
                     spacing: Kirigami.Units.smallSpacing
                     Kirigami.Icon {
@@ -730,7 +699,6 @@ Kirigami.ScrollablePage {
                     Layout.fillWidth: true
                 }
 
-                // Steam - Optional
                 RowLayout {
                     spacing: Kirigami.Units.smallSpacing
                     Kirigami.Icon {
@@ -751,7 +719,6 @@ Kirigami.ScrollablePage {
         }
     }
 
-    // Dialog components (extracted to separate files)
     Dialogs.ResetSettingsDialog {
         id: resetConfirmDialog
         settingsManager: root.settingsManager

--- a/tests/test_audiomanager.cpp
+++ b/tests/test_audiomanager.cpp
@@ -22,17 +22,12 @@ private Q_SLOTS:
     void init();
     void cleanup();
 
-    // Construction tests
     void testConstructionDefaults();
     void testPipeWireDetection();
     void testPulseAudioFallback();
-
-    // Configuration tests
     void testMultiUserConfiguredRequiresAcl();
     void testConfigurationChangedSignal();
     void testAudioServerChangedSignal();
-
-    // Socket ACL tests
     void testCheckSocketAclNonexistent();
     void testCheckSocketAclWithFakeSocket();
 
@@ -62,17 +57,13 @@ void TestAudioManager::cleanup()
     m_manager = nullptr;
 }
 
-// --- Construction tests ---
-
 void TestAudioManager::testConstructionDefaults()
 {
     m_manager = new AudioManager();
 
-    // multiUserConfigured should start false — no pipewire-0 socket in
-    // the isolated test runtime directory
+    // No pipewire-0 socket in the isolated test runtime directory
     QVERIFY(!m_manager->isMultiUserConfigured());
 
-    // audioServer should be a valid server name
     const QString server = m_manager->audioServer();
     QVERIFY2(server == QStringLiteral("pipewire") || server == QStringLiteral("pulseaudio"),
              qPrintable(QStringLiteral("Unexpected audio server: %1").arg(server)));
@@ -108,8 +99,6 @@ void TestAudioManager::testPulseAudioFallback()
     m_manager = new AudioManager();
     QCOMPARE(m_manager->audioServer(), QStringLiteral("pulseaudio"));
 }
-
-// --- Configuration tests ---
 
 void TestAudioManager::testMultiUserConfiguredRequiresAcl()
 {
@@ -181,8 +170,6 @@ void TestAudioManager::testAudioServerChangedSignal()
 
     QFile::remove(socketPath);
 }
-
-// --- Socket ACL tests ---
 
 void TestAudioManager::testCheckSocketAclNonexistent()
 {

--- a/tests/test_couchplayhelper.cpp
+++ b/tests/test_couchplayhelper.cpp
@@ -520,8 +520,6 @@ void TestCouchPlayHelper::testCreateUserLingerFailure()
         QStringLiteral("Test User")
     );
 
-    // User already exists, so should fail with "already exists"
-    // This tests the user existence check before trying to create
     QVERIFY(!reply.isValid());
     QCOMPARE(reply.error().type(), QDBusError::Failed);
 }
@@ -596,7 +594,7 @@ void TestCouchPlayHelper::testDeleteUserAuthDenied()
 void TestCouchPlayHelper::testDeleteUserNotInCouchPlayGroup()
 {
     m_ops->clear();
-    m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001, {}); // Not in group
+    m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001, {});
     m_ops->setGroupExists(QStringLiteral("input"), true, 44, {});
     m_ops->setUserExists(QStringLiteral("testuser"), true, 1002, 1002);
 
@@ -645,7 +643,7 @@ void TestCouchPlayHelper::testIsInCouchPlayGroupTrue()
 void TestCouchPlayHelper::testIsInCouchPlayGroupFalse()
 {
     m_ops->clear();
-    m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001, {}); // No members
+    m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001, {});
 
     QDBusReply<bool> reply = m_dbusInterface->call(
         QStringLiteral("IsInCouchPlayGroup"),
@@ -673,7 +671,7 @@ void TestCouchPlayHelper::testIsInCouchPlayGroupNonexistent()
 void TestCouchPlayHelper::testIsInCouchPlayGroupNonexistentGroup()
 {
     m_ops->clear();
-    m_ops->setGroupExists(QStringLiteral("couchplay"), false, 0, {}); // Group doesn't exist
+    m_ops->setGroupExists(QStringLiteral("couchplay"), false, 0, {});
 
     QDBusReply<bool> reply = m_dbusInterface->call(
         QStringLiteral("IsInCouchPlayGroup"),
@@ -900,7 +898,7 @@ void TestCouchPlayHelper::testChangeDeviceOwnerChownFails()
     m_ops->clear();
     m_ops->setUserExists(QStringLiteral("testuser"), true, 1000, 1000);
     m_ops->setFileExists(QStringLiteral("/dev/input/event0"), true);
-    m_ops->setChownResult(-1);  // chown fails
+    m_ops->setChownResult(-1);
 
     QDBusReply<bool> reply = m_dbusInterface->call(
         QStringLiteral("ChangeDeviceOwner"),
@@ -918,7 +916,7 @@ void TestCouchPlayHelper::testChangeDeviceOwnerChmodFails()
     m_ops->setUserExists(QStringLiteral("testuser"), true, 1000, 1000);
     m_ops->setFileExists(QStringLiteral("/dev/input/event0"), true);
     m_ops->setChownResult(0);
-    m_ops->setChmodResult(-1);  // chmod fails
+    m_ops->setChmodResult(-1);
 
     QDBusReply<bool> reply = m_dbusInterface->call(
         QStringLiteral("ChangeDeviceOwner"),
@@ -1156,8 +1154,8 @@ void TestCouchPlayHelper::testChangeDeviceOwnerBatchPartialFailure()
     );
 
     QStringList paths = {
-        QStringLiteral("/dev/input/event0"),  // Will succeed
-        QStringLiteral("/dev/sda")  // Invalid path - will fail
+        QStringLiteral("/dev/input/event0"),
+        QStringLiteral("/dev/sda")
     };
 
     QDBusReply<int> reply = m_dbusInterface->call(
@@ -1166,9 +1164,6 @@ void TestCouchPlayHelper::testChangeDeviceOwnerBatchPartialFailure()
         1000u
     );
 
-    // Expect D-Bus error reply (invalid input path) - reply.isValid() will be false
-    // CouchPlayHelper validates paths and returns error for /dev/sda
-    // The partial success (event0) is tracked internally, but D-Bus returns error
     QVERIFY(!reply.isValid());
 }
 
@@ -1178,8 +1173,8 @@ void TestCouchPlayHelper::testChangeDeviceOwnerBatchAllFailure()
     m_ops->setUserExists(QStringLiteral("testuser"), true, 1000, 1000);
 
     QStringList paths = {
-        QStringLiteral("/dev/sda"),  // Invalid path (not under /dev/input)
-        QStringLiteral("/dev/sdb")   // Invalid path (not under /dev/input)
+        QStringLiteral("/dev/sda"),
+        QStringLiteral("/dev/sdb")
     };
 
     QDBusReply<int> reply = m_dbusInterface->call(
@@ -1188,8 +1183,6 @@ void TestCouchPlayHelper::testChangeDeviceOwnerBatchAllFailure()
         1000u
     );
 
-    // Expect D-Bus error reply (both paths invalid) - reply.isValid() will be false
-    // CouchPlayHelper validates paths and returns error for invalid inputs
     QVERIFY(!reply.isValid());
 }
 
@@ -1234,7 +1227,6 @@ void TestCouchPlayHelper::testSetupRuntimeAccessUserNotFound()
 {
     m_ops->clear();
     m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001, {});
-    // Compositor user does not exist
 
     QDBusReply<bool> reply = m_dbusInterface->call(
         QStringLiteral("SetupRuntimeAccess"),
@@ -1254,14 +1246,12 @@ void TestCouchPlayHelper::testRemoveRuntimeAccessSuccess()
     m_ops->setFileExists(QStringLiteral("/run/user/1000/wayland-0"), true);
     m_ops->setProcessExitCode(0);
 
-    // First setup runtime access
     QDBusReply<bool> setupReply = m_dbusInterface->call(
         QStringLiteral("SetupRuntimeAccess"),
         1000u
     );
     QVERIFY(setupReply.isValid());
 
-    // Then remove it
     QDBusReply<bool> reply = m_dbusInterface->call(
         QStringLiteral("RemoveRuntimeAccess"),
         1000u

--- a/tests/test_sessionmanager.cpp
+++ b/tests/test_sessionmanager.cpp
@@ -108,12 +108,11 @@ void TestSessionManager::testInstanceCount()
     QCOMPARE(m_sessionManager->instanceCount(), 3);
     QCOMPARE(spy.count(), 1);
     
-    // Test bounds
     m_sessionManager->setInstanceCount(4);
     QCOMPARE(m_sessionManager->instanceCount(), 4);
     
     m_sessionManager->setInstanceCount(1);
-    QVERIFY(m_sessionManager->instanceCount() >= 2); // Minimum should be 2
+    QVERIFY(m_sessionManager->instanceCount() >= 2);
 }
 
 void TestSessionManager::testCurrentLayout()
@@ -138,7 +137,6 @@ void TestSessionManager::testGetInstanceConfig()
     QVERIFY(config.contains(KEY("internalHeight")));
     QVERIFY(config.contains(KEY("refreshRate")));
     
-    // Invalid instance should return empty config
     QVariantMap invalidConfig = m_sessionManager->getInstanceConfig(-1);
     QVERIFY(invalidConfig.isEmpty());
     
@@ -179,7 +177,6 @@ void TestSessionManager::testSetInstanceUser()
     QVariantMap config = m_sessionManager->getInstanceConfig(1);
     QCOMPARE(config.value(KEY("username")).toString(), QStringLiteral("player2"));
     
-    // Empty username should clear the user
     m_sessionManager->setInstanceUser(1, QString());
     config = m_sessionManager->getInstanceConfig(1);
     QVERIFY(config.value(KEY("username")).toString().isEmpty());
@@ -195,8 +192,6 @@ void TestSessionManager::testSaveProfile()
     bool result = m_sessionManager->saveProfile(QStringLiteral("TestProfile"));
     QCOMPARE(result, true);
     QCOMPARE(spy.count(), 1);
-    
-    // Current profile name should be updated
     QCOMPARE(m_sessionManager->currentProfileName(), QStringLiteral("TestProfile"));
 }
 
@@ -206,7 +201,6 @@ void TestSessionManager::testLoadProfile()
     m_sessionManager->setCurrentLayout(QStringLiteral("vertical"));
     m_sessionManager->saveProfile(QStringLiteral("LoadTestProfile"));
     
-    // Reset session before loading
     m_sessionManager->newSession();
     QCOMPARE(m_sessionManager->instanceCount(), 2);
     
@@ -216,14 +210,12 @@ void TestSessionManager::testLoadProfile()
     QCOMPARE(m_sessionManager->currentLayout(), QStringLiteral("vertical"));
     QCOMPARE(m_sessionManager->currentProfileName(), QStringLiteral("LoadTestProfile"));
     
-    // Loading non-existent profile should fail
     result = m_sessionManager->loadProfile(QStringLiteral("NonExistentProfile"));
     QCOMPARE(result, false);
 }
 
 void TestSessionManager::testDeleteProfile()
 {
-    // Save a profile first
     m_sessionManager->saveProfile(QStringLiteral("DeleteTestProfile"));
     
     QSignalSpy spy(m_sessionManager, &SessionManager::savedProfilesChanged);
@@ -231,18 +223,14 @@ void TestSessionManager::testDeleteProfile()
     bool result = m_sessionManager->deleteProfile(QStringLiteral("DeleteTestProfile"));
     QCOMPARE(result, true);
     QCOMPARE(spy.count(), 1);
-    
-    // Current profile should be cleared if it was the deleted one
     QVERIFY(m_sessionManager->currentProfileName().isEmpty());
     
-    // Deleting non-existent profile should fail
     result = m_sessionManager->deleteProfile(QStringLiteral("NonExistentProfile"));
     QCOMPARE(result, false);
 }
 
 void TestSessionManager::testSavedProfiles()
 {
-    // Clear existing profiles first
     QList<SessionProfile> profiles = m_sessionManager->savedProfiles();
     for (const SessionProfile &profile : profiles) {
         m_sessionManager->deleteProfile(profile.name);
@@ -257,7 +245,6 @@ void TestSessionManager::testSavedProfiles()
     profiles = m_sessionManager->savedProfiles();
     QCOMPARE(profiles.size(), initialCount + 2);
     
-    // Profiles should contain expected data
     bool foundProfile1 = false;
     bool foundProfile2 = false;
     for (const SessionProfile &profile : profiles) {
@@ -277,8 +264,6 @@ void TestSessionManager::testRefreshProfiles()
     QSignalSpy spy(m_sessionManager, &SessionManager::savedProfilesChanged);
     
     m_sessionManager->refreshProfiles();
-    
-    // Should emit savedProfilesChanged
     QCOMPARE(spy.count(), 1);
 }
 
@@ -288,8 +273,6 @@ void TestSessionManager::testInstanceCountChangedSignal()
     
     m_sessionManager->setInstanceCount(3);
     QCOMPARE(spy.count(), 1);
-    
-    // Setting same value shouldn't emit
     m_sessionManager->setInstanceCount(3);
     QCOMPARE(spy.count(), 1);
 }
@@ -300,8 +283,6 @@ void TestSessionManager::testCurrentLayoutChangedSignal()
     
     m_sessionManager->setCurrentLayout(QStringLiteral("grid"));
     QCOMPARE(spy.count(), 1);
-    
-    // Setting same value shouldn't emit
     m_sessionManager->setCurrentLayout(QStringLiteral("grid"));
     QCOMPARE(spy.count(), 1);
 }
@@ -322,7 +303,7 @@ void TestSessionManager::testGetAssignedUsers()
     m_sessionManager->newSession();
     m_sessionManager->setInstanceCount(3);
     
-    m_sessionManager->setInstanceUser(0, QString());  // Primary user (empty string)
+    m_sessionManager->setInstanceUser(0, QString());
     m_sessionManager->setInstanceUser(1, QStringLiteral("player2"));
     m_sessionManager->setInstanceUser(2, QStringLiteral("player3"));
     
@@ -339,7 +320,6 @@ void TestSessionManager::testGetAssignedUsers()
     QCOMPARE(assigned.size(), 1);
     QVERIFY(assigned.contains(QStringLiteral("player2")));
     
-    // Empty usernames should not be included
     m_sessionManager->setInstanceUser(1, QString());
     assigned = m_sessionManager->getAssignedUsers(0);
     QCOMPARE(assigned.size(), 1);


### PR DESCRIPTION
## Summary
- Add screensaver inhibition via `org.freedesktop.ScreenSaver` D-Bus during active gaming sessions, with automatic release on session stop or when all instances end
- Remove redundant AI-generated comments across helper, core managers, QML pages, and tests (108 insertions, 239 deletions net)

## Changes
- **`SessionRunner`**: Inhibit screensaver on session start, uninhibit on stop/instance end
- **`CouchPlayHelper`**: Remove obvious inline comments, fix indentation bug in `ResetAllDevices`
- **`PresetManager`**: Remove verbose doxygen from trivial getters/setters, consolidate multi-line comments
- **`GamescopeInstance`/`WindowManager`**: Remove self-explanatory comments
- **QML pages**: Remove section label comments (HomePage, SessionSetupPage, SettingsPage)
- **Tests**: Remove section dividers and obvious test-step comments

## Design-decision comments preserved
The following non-obvious comments were intentionally kept:
- `// Steam can't run multiple instances under the same user` (business constraint)
- `// Sequential launch: fixes race condition with window positioning` (design rationale)
- `// Otherwise wait for onWindowPositioned to trigger the next start` (async control flow)
- `// Don't increment i since we removed the current element` (loop behavior)