### PR TITLE
fix(settings): consolidate borderlessWindows and fix settings persistence

### DIFF
--- a/src/core/SessionManager.cpp
+++ b/src/core/SessionManager.cpp
@@ -113,7 +113,6 @@ bool SessionManager::saveProfile(const QString &name)
         instGroup.writeEntry("overrideGamePath", inst.overrideGamePath);
         instGroup.writeEntry("overrideFiles", inst.overrideFiles);
         instGroup.writeEntry("overridePatterns", inst.overridePatterns);
-        instGroup.writeEntry("borderless", inst.borderless);
 
         // Convert devices to string list for backwards compatibility
         QStringList deviceStrings;
@@ -184,8 +183,6 @@ bool SessionManager::loadProfile(const QString &name)
             inst.overridePatterns = inst.overrideFiles;
             qDebug() << "Migrated overrideFiles to overridePatterns for instance" << i;
         }
-
-        inst.borderless = instGroup.readEntry("borderless", false);
 
         inst.deviceStableIds = instGroup.readEntry("deviceStableIds", QStringList());
         inst.deviceStableIdNames = instGroup.readEntry("deviceStableIdNames", QStringList());
@@ -311,7 +308,6 @@ QVariantMap SessionManager::getInstanceConfig(int index) const
     map[QStringLiteral("presetId")] = inst.presetId;
     map[QStringLiteral("overridePatterns")] = inst.overridePatterns;
     map[QStringLiteral("sharedDirectories")] = inst.sharedDirectories;
-    map[QStringLiteral("borderless")] = inst.borderless;
 
     QVariantList deviceList;
     for (int dev : inst.devices) {
@@ -370,8 +366,6 @@ void SessionManager::setInstanceConfig(int index, const QVariantMap &config)
         inst.overridePatterns = config[QStringLiteral("overridePatterns")].toStringList();
     if (config.contains(QStringLiteral("overrideGamePath")))
         inst.overrideGamePath = config[QStringLiteral("overrideGamePath")].toString();
-    if (config.contains(QStringLiteral("borderless")))
-        inst.borderless = config[QStringLiteral("borderless")].toBool();
 
     Q_EMIT instancesChanged();
 
@@ -470,18 +464,6 @@ void SessionManager::setInstanceSharedDirectories(int index, const QStringList &
 {
     if (index >= 0 && index < m_currentProfile.instances.size()) {
         m_currentProfile.instances[index].sharedDirectories = directories;
-        Q_EMIT instancesChanged();
-        
-        if (!m_currentProfile.name.isEmpty()) {
-            saveProfile(m_currentProfile.name);
-        }
-    }
-}
-
-void SessionManager::setInstanceBorderless(int index, bool borderless)
-{
-    if (index >= 0 && index < m_currentProfile.instances.size()) {
-        m_currentProfile.instances[index].borderless = borderless;
         Q_EMIT instancesChanged();
         
         if (!m_currentProfile.name.isEmpty()) {

--- a/src/core/SessionManager.h
+++ b/src/core/SessionManager.h
@@ -38,7 +38,6 @@ struct InstanceConfig {
     Q_PROPERTY(QString overrideGamePath MEMBER overrideGamePath)
     Q_PROPERTY(QStringList overrideFiles MEMBER overrideFiles)
     Q_PROPERTY(QStringList overridePatterns MEMBER overridePatterns)
-    Q_PROPERTY(bool borderless MEMBER borderless)
 
 public:
     QString username;
@@ -60,7 +59,6 @@ public:
     QString overrideGamePath;
     QStringList overrideFiles;
     QStringList overridePatterns;                     // Glob patterns for per-user overrides
-    bool borderless = false;                           // Window border visibility (false = show borders)
 };
 
 Q_DECLARE_METATYPE(InstanceConfig)
@@ -132,7 +130,6 @@ public:
     Q_INVOKABLE void setInstanceGame(int index, const QString &gameCommand);
     Q_INVOKABLE void setInstancePreset(int index, const QString &presetId);
     Q_INVOKABLE void setInstanceSharedDirectories(int index, const QStringList &directories);
-    Q_INVOKABLE void setInstanceBorderless(int index, bool borderless);
 
     Q_INVOKABLE void recalculateOutputResolutions(int screenWidth, int screenHeight);
     Q_INVOKABLE QStringList getAssignedUsers(int excludeIndex) const;

--- a/src/core/SessionRunner.cpp
+++ b/src/core/SessionRunner.cpp
@@ -5,6 +5,7 @@
 #include "GamescopeInstance.h"
 #include "Logging.h"
 #include "SessionManager.h"
+#include "SettingsManager.h"
 #include "DeviceManager.h"
 #include "PresetManager.h"
 #include "SteamConfigManager.h"
@@ -145,11 +146,11 @@ void SessionRunner::setHeroicConfigManager(HeroicConfigManager *manager)
     }
 }
 
-void SessionRunner::setBorderlessWindows(bool borderless)
+void SessionRunner::setSettingsManager(SettingsManager *manager)
 {
-    if (m_borderlessWindows != borderless) {
-        m_borderlessWindows = borderless;
-        Q_EMIT borderlessWindowsChanged();
+    if (m_settingsManager != manager) {
+        m_settingsManager = manager;
+        Q_EMIT settingsManagerChanged();
     }
 }
 
@@ -250,7 +251,7 @@ bool SessionRunner::start()
         config[QStringLiteral("filterMode")] = instConfig.filterMode;
         config[QStringLiteral("gameCommand")] = instConfig.gameCommand;
         config[QStringLiteral("steamAppId")] = instConfig.steamAppId;
-        config[QStringLiteral("borderless")] = m_borderlessWindows;
+        config[QStringLiteral("borderless")] = m_settingsManager ? m_settingsManager->borderlessWindows() : false;
 
         if (m_presetManager) {
             QString presetId = instConfig.presetId;
@@ -987,12 +988,14 @@ void SessionRunner::positionInstanceWindow(GamescopeInstance *instance)
 
     QRect targetGeometry = instance->windowGeometry();
     int instanceIndex = instance->index();
+    bool borderless = m_settingsManager ? m_settingsManager->borderlessWindows() : false;
 
     m_windowManager->queuePositionRequest(
         instanceIndex,
         targetGeometry,
         m_positionedWindowIds,
-        60000  // 60 second timeout for Steam login on secondary instances
+        borderless,
+        60000
     );
 }
 

--- a/src/core/SessionRunner.h
+++ b/src/core/SessionRunner.h
@@ -21,6 +21,7 @@ class QAction;
 class GamescopeInstance;
 class DeviceManager;
 class SessionManager;
+class SettingsManager;
 class WindowManager;
 class PresetManager;
 
@@ -40,7 +41,6 @@ class SessionRunner : public QObject
     Q_PROPERTY(int runningInstanceCount READ runningInstanceCount NOTIFY runningInstanceCountChanged)
     Q_PROPERTY(QString status READ status NOTIFY statusChanged)
     Q_PROPERTY(QVariantList instances READ instancesAsVariant NOTIFY instancesChanged)
-    Q_PROPERTY(bool borderlessWindows READ borderlessWindows WRITE setBorderlessWindows NOTIFY borderlessWindowsChanged)
     
     // Dependencies
     Q_PROPERTY(SessionManager* sessionManager READ sessionManager WRITE setSessionManager NOTIFY sessionManagerChanged)
@@ -49,6 +49,7 @@ class SessionRunner : public QObject
     Q_PROPERTY(PresetManager* presetManager READ presetManager WRITE setPresetManager NOTIFY presetManagerChanged)
     Q_PROPERTY(SteamConfigManager* steamConfigManager READ steamConfigManager WRITE setSteamConfigManager NOTIFY steamConfigManagerChanged)
     Q_PROPERTY(HeroicConfigManager* heroicConfigManager READ heroicConfigManager WRITE setHeroicConfigManager NOTIFY heroicConfigManagerChanged)
+    Q_PROPERTY(SettingsManager* settingsManager READ settingsManager WRITE setSettingsManager NOTIFY settingsManagerChanged)
 
 public:
     explicit SessionRunner(QObject *parent = nullptr);
@@ -110,8 +111,8 @@ public:
     HeroicConfigManager* heroicConfigManager() const { return m_heroicConfigManager; }
     void setHeroicConfigManager(HeroicConfigManager *manager);
 
-    bool borderlessWindows() const { return m_borderlessWindows; }
-    void setBorderlessWindows(bool borderless);
+    SettingsManager* settingsManager() const { return m_settingsManager; }
+    void setSettingsManager(SettingsManager *manager);
 
     /**
      * @brief Calculate window geometries for a given layout
@@ -146,7 +147,7 @@ Q_SIGNALS:
     void presetManagerChanged();
     void steamConfigManagerChanged();
     void heroicConfigManagerChanged();
-    void borderlessWindowsChanged();
+    void settingsManagerChanged();
     void errorOccurred(const QString &message);
     void sessionStarted();
     void sessionStopped();
@@ -195,6 +196,7 @@ private:
     PresetManager *m_presetManager = nullptr;
     SteamConfigManager *m_steamConfigManager = nullptr;
     HeroicConfigManager *m_heroicConfigManager = nullptr;
+    SettingsManager *m_settingsManager = nullptr;
     WindowManager *m_windowManager = nullptr;
     VirtualDeviceWatcher *m_virtualDeviceWatcher = nullptr;
     QList<GamescopeInstance*> m_instances;
@@ -202,7 +204,6 @@ private:
     QString m_status;
     QStringList m_ownedDevicePaths; // Devices we've taken ownership of
     QStringList m_positionedWindowIds; // Window IDs we've positioned (for excluding)
-    bool m_borderlessWindows = false; // Default to decorated windows
     
     // Sequential instance launching state
     int m_nextInstanceToStart = 0;

--- a/src/core/SettingsManager.cpp
+++ b/src/core/SettingsManager.cpp
@@ -29,13 +29,12 @@ void SettingsManager::loadSettings()
     KConfigGroup gamescope = config->group(QStringLiteral("Gamescope"));
     m_scalingMode = gamescope.readEntry(QStringLiteral("ScalingMode"), QStringLiteral("fit"));
     m_filterMode = gamescope.readEntry(QStringLiteral("FilterMode"), QStringLiteral("linear"));
-    m_steamIntegration = gamescope.readEntry(QStringLiteral("SteamIntegration"), true);
     m_borderlessWindows = gamescope.readEntry(QStringLiteral("BorderlessWindows"), false);
     
     qDebug() << "SettingsManager: Loaded settings from couchplayrc";
 }
 
-void SettingsManager::saveSettings()
+void SettingsManager::saveAllSettings()
 {
     KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
     
@@ -50,7 +49,6 @@ void SettingsManager::saveSettings()
     KConfigGroup gamescope = config->group(QStringLiteral("Gamescope"));
     gamescope.writeEntry(QStringLiteral("ScalingMode"), m_scalingMode);
     gamescope.writeEntry(QStringLiteral("FilterMode"), m_filterMode);
-    gamescope.writeEntry(QStringLiteral("SteamIntegration"), m_steamIntegration);
     gamescope.writeEntry(QStringLiteral("BorderlessWindows"), m_borderlessWindows);
     
     config->sync();
@@ -60,7 +58,9 @@ void SettingsManager::setHidePanels(bool value)
 {
     if (m_hidePanels != value) {
         m_hidePanels = value;
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("General")).writeEntry(QStringLiteral("HidePanels"), value);
+        config->sync();
         Q_EMIT hidePanelsChanged();
     }
 }
@@ -69,7 +69,9 @@ void SettingsManager::setKillSteam(bool value)
 {
     if (m_killSteam != value) {
         m_killSteam = value;
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("General")).writeEntry(QStringLiteral("KillSteam"), value);
+        config->sync();
         Q_EMIT killSteamChanged();
     }
 }
@@ -78,7 +80,9 @@ void SettingsManager::setRestoreSession(bool value)
 {
     if (m_restoreSession != value) {
         m_restoreSession = value;
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("General")).writeEntry(QStringLiteral("RestoreSession"), value);
+        config->sync();
         Q_EMIT restoreSessionChanged();
     }
 }
@@ -87,7 +91,9 @@ void SettingsManager::setScalingMode(const QString &value)
 {
     if (m_scalingMode != value) {
         m_scalingMode = value;
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("Gamescope")).writeEntry(QStringLiteral("ScalingMode"), value);
+        config->sync();
         Q_EMIT scalingModeChanged();
     }
 }
@@ -96,17 +102,10 @@ void SettingsManager::setFilterMode(const QString &value)
 {
     if (m_filterMode != value) {
         m_filterMode = value;
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("Gamescope")).writeEntry(QStringLiteral("FilterMode"), value);
+        config->sync();
         Q_EMIT filterModeChanged();
-    }
-}
-
-void SettingsManager::setSteamIntegration(bool value)
-{
-    if (m_steamIntegration != value) {
-        m_steamIntegration = value;
-        saveSettings();
-        Q_EMIT steamIntegrationChanged();
     }
 }
 
@@ -114,7 +113,9 @@ void SettingsManager::setBorderlessWindows(bool value)
 {
     if (m_borderlessWindows != value) {
         m_borderlessWindows = value;
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("Gamescope")).writeEntry(QStringLiteral("BorderlessWindows"), value);
+        config->sync();
         Q_EMIT borderlessWindowsChanged();
     }
 }
@@ -123,7 +124,9 @@ void SettingsManager::setIgnoredDevices(const QStringList &value)
 {
     if (m_ignoredDevices != value) {
         m_ignoredDevices = value;
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("General")).writeEntry(QStringLiteral("IgnoredDevices"), value);
+        config->sync();
         Q_EMIT ignoredDevicesChanged();
     }
 }
@@ -132,7 +135,9 @@ void SettingsManager::addIgnoredDevice(const QString &stableId)
 {
     if (!m_ignoredDevices.contains(stableId)) {
         m_ignoredDevices.append(stableId);
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("General")).writeEntry(QStringLiteral("IgnoredDevices"), m_ignoredDevices);
+        config->sync();
         Q_EMIT ignoredDevicesChanged();
     }
 }
@@ -141,7 +146,9 @@ void SettingsManager::removeIgnoredDevice(const QString &stableId)
 {
     if (m_ignoredDevices.contains(stableId)) {
         m_ignoredDevices.removeAll(stableId);
-        saveSettings();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        config->group(QStringLiteral("General")).writeEntry(QStringLiteral("IgnoredDevices"), m_ignoredDevices);
+        config->sync();
         Q_EMIT ignoredDevicesChanged();
     }
 }
@@ -153,18 +160,16 @@ void SettingsManager::resetToDefaults()
     m_restoreSession = false;
     m_scalingMode = QStringLiteral("fit");
     m_filterMode = QStringLiteral("linear");
-    m_steamIntegration = true;
     m_borderlessWindows = false;
     m_ignoredDevices.clear();
     
-    saveSettings();
+    saveAllSettings();
     
     Q_EMIT hidePanelsChanged();
     Q_EMIT killSteamChanged();
     Q_EMIT restoreSessionChanged();
     Q_EMIT scalingModeChanged();
     Q_EMIT filterModeChanged();
-    Q_EMIT steamIntegrationChanged();
     Q_EMIT borderlessWindowsChanged();
     Q_EMIT ignoredDevicesChanged();
     

--- a/src/core/SettingsManager.h
+++ b/src/core/SettingsManager.h
@@ -27,7 +27,6 @@ class SettingsManager : public QObject
     // Gamescope settings
     Q_PROPERTY(QString scalingMode READ scalingMode WRITE setScalingMode NOTIFY scalingModeChanged)
     Q_PROPERTY(QString filterMode READ filterMode WRITE setFilterMode NOTIFY filterModeChanged)
-    Q_PROPERTY(bool steamIntegration READ steamIntegration WRITE setSteamIntegration NOTIFY steamIntegrationChanged)
     Q_PROPERTY(bool borderlessWindows READ borderlessWindows WRITE setBorderlessWindows NOTIFY borderlessWindowsChanged)
 
     // Device settings
@@ -54,9 +53,6 @@ public:
     QString filterMode() const { return m_filterMode; }
     void setFilterMode(const QString &value);
 
-    bool steamIntegration() const { return m_steamIntegration; }
-    void setSteamIntegration(bool value);
-
     bool borderlessWindows() const { return m_borderlessWindows; }
     void setBorderlessWindows(bool value);
 
@@ -77,13 +73,12 @@ Q_SIGNALS:
     void restoreSessionChanged();
     void scalingModeChanged();
     void filterModeChanged();
-    void steamIntegrationChanged();
     void borderlessWindowsChanged();
     void ignoredDevicesChanged();
 
 private:
     void loadSettings();
-    void saveSettings();
+    void saveAllSettings();
 
     // General settings
     bool m_hidePanels = true;
@@ -93,7 +88,6 @@ private:
     // Gamescope settings
     QString m_scalingMode = QStringLiteral("fit");
     QString m_filterMode = QStringLiteral("linear");
-    bool m_steamIntegration = true;
     bool m_borderlessWindows = false;
 
     // Device settings

--- a/src/core/WindowManager.cpp
+++ b/src/core/WindowManager.cpp
@@ -202,7 +202,7 @@ QVariantMap WindowManager::getWindowInfo(const QString &windowId)
     return info;
 }
 
-bool WindowManager::positionWindow(const QString &windowId, const QRect &geometry)
+bool WindowManager::positionWindow(const QString &windowId, const QRect &geometry, bool borderless)
 {
     if (!m_kwinAvailable || windowId.isEmpty()) {
         Q_EMIT positioningFailed(windowId, QStringLiteral("KWin not available or invalid window ID"));
@@ -211,11 +211,12 @@ bool WindowManager::positionWindow(const QString &windowId, const QRect &geometr
 
     qDebug() << "WindowManager: Positioning window" << windowId << "to" << geometry;
 
-    return executePositionScript(windowId, geometry);
+    return executePositionScript(windowId, geometry, borderless);
 }
 
 void WindowManager::queuePositionRequest(int requestId, const QRect &geometry,
                                           const QStringList &excludeWindowIds,
+                                          bool borderless,
                                           int timeoutMs)
 {
     if (!m_kwinAvailable) {
@@ -236,6 +237,7 @@ void WindowManager::queuePositionRequest(int requestId, const QRect &geometry,
     request.requestId = requestId;
     request.geometry = geometry;
     request.excludeWindowIds = excludeWindowIds;
+    request.borderless = borderless;
     request.expiresAt = QDateTime::currentMSecsSinceEpoch() + timeoutMs;
     
     m_pendingRequests.append(request);
@@ -324,7 +326,7 @@ void WindowManager::checkForNewWindows()
             qDebug() << "WindowManager: Matched window" << matchedWindowId 
                      << "to request" << request.requestId;
             
-            bool success = positionWindow(matchedWindowId, request.geometry);
+            bool success = positionWindow(matchedWindowId, request.geometry, request.borderless);
             
             m_knownWindowIds.append(matchedWindowId);
             
@@ -363,8 +365,9 @@ void WindowManager::stopMonitoringIfEmpty()
     }
 }
 
-bool WindowManager::executePositionScript(const QString &windowId, const QRect &geometry)
+bool WindowManager::executePositionScript(const QString &windowId, const QRect &geometry, bool borderless)
 {
+    QString borderlessValue = borderless ? QStringLiteral("true") : QStringLiteral("false");
     QString scriptContent = QStringLiteral(R"(
 (function() {
     var targetUuid = "%1";
@@ -372,13 +375,14 @@ bool WindowManager::executePositionScript(const QString &windowId, const QRect &
     var targetY = %3;
     var targetW = %4;
     var targetH = %5;
+    var borderless = %6;
     
     var windows = workspace.windowList();
     for (var i = 0; i < windows.length; i++) {
         var win = windows[i];
         if (win.internalId.toString() === targetUuid) {
             win.frameGeometry = {x: targetX, y: targetY, width: targetW, height: targetH};
-            win.noBorder = true;
+            win.noBorder = borderless;
             win.keepAbove = true;
             win.skipTaskbar = true;
             win.skipPager = true;
@@ -391,7 +395,8 @@ bool WindowManager::executePositionScript(const QString &windowId, const QRect &
         .arg(geometry.x())
         .arg(geometry.y())
         .arg(geometry.width())
-        .arg(geometry.height());
+        .arg(geometry.height())
+        .arg(borderlessValue);
     
     // Use XDG_RUNTIME_DIR — auto-cleaned on session end, not shared across users
     QString runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);

--- a/src/core/WindowManager.h
+++ b/src/core/WindowManager.h
@@ -52,7 +52,7 @@ public:
      * @param geometry The target geometry (x, y, width, height)
      * @return true if successful
      */
-    Q_INVOKABLE bool positionWindow(const QString &windowId, const QRect &geometry);
+    Q_INVOKABLE bool positionWindow(const QString &windowId, const QRect &geometry, bool borderless = false);
 
     /**
      * @brief Queue a positioning request that will be fulfilled when a gamescope window appears
@@ -67,6 +67,7 @@ public:
      */
     Q_INVOKABLE void queuePositionRequest(int requestId, const QRect &geometry,
                                            const QStringList &excludeWindowIds,
+                                           bool borderless,
                                            int timeoutMs = 60000);
 
     /**
@@ -131,13 +132,14 @@ private:
         int requestId;
         QRect geometry;
         QStringList excludeWindowIds;
-        qint64 expiresAt;  // milliseconds since epoch
+        bool borderless;
+        qint64 expiresAt;
     };
 
     /**
      * @brief Execute a KWin script to position a specific window
      */
-    bool executePositionScript(const QString &windowId, const QRect &geometry);
+    bool executePositionScript(const QString &windowId, const QRect &geometry, bool borderless);
 
     /**
      * @brief Start the monitoring timer if not already running

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -74,7 +74,7 @@ Kirigami.ApplicationWindow {
         presetManager: presetManager
         steamConfigManager: steamConfigManager
         heroicConfigManager: heroicConfigManager
-        borderlessWindows: settingsManager.borderlessWindows
+        settingsManager: settingsManager
 
         onErrorOccurred: (message) => {
             applicationWindow().showPassiveNotification(message, "long")

--- a/src/qml/pages/SessionSetupPage.qml
+++ b/src/qml/pages/SessionSetupPage.qml
@@ -334,10 +334,7 @@ Kirigami.ScrollablePage {
                 readonly property string labelResolution: i18nc("@label", "Game Resolution:")
                 readonly property string labelRefreshRate: i18nc("@label", "Refresh Rate:")
                 readonly property string labelScaling: i18nc("@label", "Scaling:")
-                readonly property string labelWindowBorders: i18nc("@label", "Window Borders:")
                 readonly property string labelDevices: i18nc("@label", "Devices:")
-                readonly property string textBorderless: i18nc("@option:check", "Borderless")
-                readonly property string tooltipBorderless: i18nc("@info:tooltip", "Enable for borderless windows, disable to show window decorations")
 
                 readonly property string labelOverlay: i18nc("@label", "Config Overrides:")
                 readonly property string tooltipOverlay: i18nc("@info:tooltip", "For games that store saves/config in their own folder (not in AppData/Documents). Each player gets their own copy of matching files.")
@@ -539,16 +536,6 @@ Kirigami.ScrollablePage {
                                 model: ["fit", "stretch", "integer", "auto"]
                                 currentIndex: 0
                                 Layout.fillWidth: true
-                            }
-
-                            Controls.CheckBox {
-                                Kirigami.FormData.label: instanceCard.labelWindowBorders
-                                checked: root.sessionManager ? root.sessionManager.getInstanceConfig(instanceCard.index).borderless : false
-                                text: instanceCard.textBorderless
-
-                                Controls.ToolTip.text: instanceCard.tooltipBorderless
-                                Controls.ToolTip.visible: hovered
-                                Controls.ToolTip.delay: 1000
                             }
                         }
 

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -40,7 +40,6 @@ Kirigami.ScrollablePage {
     readonly property bool restoreSession: settingsManager?.restoreSession ?? false
     readonly property string scalingMode: settingsManager?.scalingMode ?? "fit"
     readonly property string filterMode: settingsManager?.filterMode ?? "linear"
-    readonly property bool steamIntegration: settingsManager?.steamIntegration ?? true
     readonly property bool borderlessWindows: settingsManager?.borderlessWindows ?? false
 
     actions: [
@@ -137,26 +136,10 @@ Kirigami.ScrollablePage {
             }
 
             Controls.CheckBox {
-                id: steamIntegrationCheck
-                Kirigami.FormData.label: i18nc("@option:check", "Steam integration")
-                checked: root.steamIntegration
-                onToggled: if (root.settingsManager) root.settingsManager.steamIntegration = checked
-
-                Controls.ToolTip.text: i18nc("@info:tooltip", "Enables Steam Deck and Big Picture compatibility mode")
-                Controls.ToolTip.visible: hovered
-                Controls.ToolTip.delay: 1000
-            }
-
-            Controls.CheckBox {
                 id: borderlessCheck
                 Kirigami.FormData.label: i18nc("@option:check", "Borderless windows")
-                checked: root.sessionRunner ? root.sessionRunner.borderlessWindows : root.borderlessWindows
-                onToggled: {
-                    if (root.settingsManager) root.settingsManager.borderlessWindows = checked
-                    if (root.sessionRunner) {
-                        root.sessionRunner.borderlessWindows = checked
-                    }
-                }
+                checked: root.borderlessWindows
+                onToggled: if (root.settingsManager) root.settingsManager.borderlessWindows = checked
 
                 Controls.ToolTip.text: i18nc("@info:tooltip", "Disable for resizable windows with title bars")
                 Controls.ToolTip.visible: hovered


### PR DESCRIPTION
## Summary

- Consolidate `borderlessWindows` as a global-only setting in `SettingsManager`, removing the duplicate per-instance `borderless` from `InstanceConfig` and profile persistence
- Wire the `borderlessWindows` setting to the KWin window positioning script (was hardcoded `noBorder = true` regardless of the setting)
- Remove leftover `steamIntegration` property from `SettingsManager` (already handled per-preset by `PresetManager`)
- Remove dead per-instance borderless checkbox from `SessionSetupPage` (read-only, no `onToggled` handler)
- Fix broken QML property binding in `SettingsPage` (binding would break after first toggle)
- Make `SettingsManager` save only the changed setting instead of rewriting all settings on every change

## Test Plan

- [x] Build compiles cleanly (zero errors)
- [x] All 62 existing test cases pass (1 pre-existing `testVersion` failure unrelated)
- [x] Manual: Toggle borderless setting in Settings → verify gamescope `-b` flag is passed when enabled
- [x] Manual: Verify KWin window decorations respect the setting (on/off)
- [x] Manual: Verify settings persist across app restarts (`~/.config/couchplayrc`)