### PR TITLE
fix(audio): clear runtime access tracking on TCP listener teardown

### DIFF
--- a/helper/CouchPlayHelper.cpp
+++ b/helper/CouchPlayHelper.cpp
@@ -1181,6 +1181,7 @@ void CouchPlayHelper::cleanupTcpListenerIfLast(const QString &username)
 
     if (!hasOtherInstances) {
         removePulseTcpListener(compositorUid);
+        m_runtimeAccessSetForUid.remove(compositorUid);
     }
 }
 


### PR DESCRIPTION
## Summary

- Clear `m_runtimeAccessSetForUid` in `cleanupTcpListenerIfLast()` when the TCP listener config is removed, so `SetupRuntimeAccess()` re-runs on the next session start and recreates the PipeWire PulseAudio TCP listener

## Problem

Audio routing broke after closing instances and starting a new session. The TCP listener config (`50-couchplay.conf`) was removed during teardown, but `m_runtimeAccessSetForUid` still contained the compositor UID. On the next launch, `LaunchInstance()` saw the UID in the set and skipped `SetupRuntimeAccess()` entirely — so the TCP listener was never recreated. Instances launched with `PULSE_SERVER=tcp:127.0.0.1:4713` but nothing was listening.

Workaround was reinstalling the helper, which restarts the daemon and clears the in-memory set.

## Testing

- Built and linked `couchplay` and `couchplay-helper` successfully
- Single-line fix in `helper/CouchPlayHelper.cpp`