### PR TITLE
feat(steam): share game library with gaming users via bind mounts

### DIFF
--- a/src/core/SessionRunner.cpp
+++ b/src/core/SessionRunner.cpp
@@ -344,6 +344,16 @@ void SessionRunner::stop()
     restoreDeviceOwnership();
     teardownSharedDirectories();
 
+    if (m_steamConfigManager && m_steamConfigManager->shareLibraryEnabled() && m_sessionManager) {
+        const auto &profile = m_sessionManager->currentProfile();
+        for (int i = 0; i < profile.instances.size(); ++i) {
+            const QString &username = profile.instances[i].username;
+            if (!username.isEmpty()) {
+                m_steamConfigManager->cleanupLibrarySharing(username);
+            }
+        }
+    }
+
     cleanupInstances();
     cleanupOverrideDirs(overridePaths);
 
@@ -683,6 +693,10 @@ bool SessionRunner::setupLauncherAccess()
     const auto &profile = m_sessionManager->currentProfile();
     bool allSucceeded = true;
 
+    if (m_steamConfigManager && m_steamConfigManager->shareLibraryEnabled() && m_steamConfigManager->isSteamDetected()) {
+        m_steamConfigManager->loadLibraryFolders();
+    }
+
     for (int i = 0; i < profile.instances.size(); ++i) {
         const QString &username = profile.instances[i].username;
         const QString &presetId = profile.instances[i].presetId;
@@ -730,11 +744,6 @@ bool SessionRunner::setupLauncherAccess()
             continue;
         }
 
-        if (!m_steamConfigManager->syncShortcutsEnabled()) {
-            qCDebug(couchplaySteam) << "Shortcut sync disabled, skipping";
-            continue;
-        }
-
         if (!m_steamConfigManager->isSteamDetected()) {
             m_steamConfigManager->detectSteamPaths();
         }
@@ -750,25 +759,38 @@ bool SessionRunner::setupLauncherAccess()
             continue;
         }
 
-        m_steamConfigManager->loadShortcuts();
-        QStringList shortcutDirs = m_steamConfigManager->extractShortcutDirectories();
-        qCDebug(couchplaySteam) << "Found" << shortcutDirs.size() << "directories in shortcuts";
+        if (m_steamConfigManager->syncShortcutsEnabled()) {
+            m_steamConfigManager->loadShortcuts();
+            QStringList shortcutDirs = m_steamConfigManager->extractShortcutDirectories();
+            qCDebug(couchplaySteam) << "Found" << shortcutDirs.size() << "directories in shortcuts";
 
-        qCDebug(couchplaySteam) << "Setting up Steam shortcuts for user" << username;
+            qCDebug(couchplaySteam) << "Setting up Steam shortcuts for user" << username;
 
-        for (const QString &dir : shortcutDirs) {
-            if (QDir(dir).exists()) {
-                qCDebug(couchplaySteam) << "Setting ACL with parents on" << dir << "for" << username;
-                if (!m_helperClient->setPathAclWithParents(dir, username)) {
-                    qCWarning(couchplaySteam) << "Failed to set ACL on" << dir;
+            for (const QString &dir : shortcutDirs) {
+                if (QDir(dir).exists()) {
+                    qCDebug(couchplaySteam) << "Setting ACL with parents on" << dir << "for" << username;
+                    if (!m_helperClient->setPathAclWithParents(dir, username)) {
+                        qCWarning(couchplaySteam) << "Failed to set ACL on" << dir;
+                    }
                 }
             }
+
+            qCDebug(couchplaySteam) << "Calling syncShortcutsToUser for" << username;
+            if (!m_steamConfigManager->syncShortcutsToUser(username)) {
+                qCWarning(couchplaySteam) << "Failed to sync shortcuts to user" << username;
+                allSucceeded = false;
+            }
+        } else {
+            qCDebug(couchplaySteam) << "Shortcut sync disabled, skipping";
         }
 
-        qCDebug(couchplaySteam) << "Calling syncShortcutsToUser for" << username;
-        if (!m_steamConfigManager->syncShortcutsToUser(username)) {
-            qCWarning(couchplaySteam) << "Failed to sync shortcuts to user" << username;
-            allSucceeded = false;
+        // Share Steam library if enabled
+        if (m_steamConfigManager->shareLibraryEnabled()) {
+            qCDebug(couchplaySteam) << "Sharing Steam library for user" << username;
+            if (!m_steamConfigManager->shareLibraryToUser(username)) {
+                qCWarning(couchplaySteam) << "Failed to share Steam library to" << username;
+                allSucceeded = false;
+            }
         }
     }
 

--- a/src/core/SteamConfigManager.cpp
+++ b/src/core/SteamConfigManager.cpp
@@ -40,6 +40,7 @@ SteamConfigManager::SteamConfigManager(QObject *parent)
     KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
     KConfigGroup group = config->group(QStringLiteral("Steam"));
     m_syncShortcutsEnabled = group.readEntry(QStringLiteral("SyncShortcutsEnabled"), false);
+    m_shareLibraryEnabled = group.readEntry(QStringLiteral("ShareLibraryEnabled"), false);
 }
 
 void SteamConfigManager::setHelperClient(CouchPlayHelperClient *client)
@@ -62,6 +63,20 @@ void SteamConfigManager::setSyncShortcutsEnabled(bool enabled)
         config->sync();
 
         Q_EMIT syncShortcutsEnabledChanged();
+    }
+}
+
+void SteamConfigManager::setShareLibraryEnabled(bool enabled)
+{
+    if (m_shareLibraryEnabled != enabled) {
+        m_shareLibraryEnabled = enabled;
+        
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(QStringLiteral("couchplayrc"));
+        KConfigGroup group = config->group(QStringLiteral("Steam"));
+        group.writeEntry(QStringLiteral("ShareLibraryEnabled"), enabled);
+        config->sync();
+        
+        Q_EMIT shareLibraryEnabledChanged();
     }
 }
 
@@ -609,4 +624,364 @@ QList<SteamShortcut> SteamConfigManager::parseShortcutsVdf(const QString &path)
     }
 
     return result;
+}
+
+void SteamConfigManager::loadLibraryFolders()
+{
+    m_libraries.clear();
+    
+    if (!m_steamPaths.valid || m_steamPaths.libraryFoldersVdf.isEmpty()) {
+        qCWarning(couchplaySteam) << "Cannot load library folders - Steam not detected";
+        Q_EMIT librariesLoaded();
+        return;
+    }
+    
+    if (!QFile::exists(m_steamPaths.libraryFoldersVdf)) {
+        qCDebug(couchplaySteam) << "libraryfolders.vdf not found at" << m_steamPaths.libraryFoldersVdf;
+        Q_EMIT librariesLoaded();
+        return;
+    }
+    
+    m_libraries = parseLibraryFoldersVdf(m_steamPaths.libraryFoldersVdf);
+    qCDebug(couchplaySteam) << "Loaded" << m_libraries.size() << "library folders";
+    
+    Q_EMIT librariesLoaded();
+}
+
+QVariantList SteamConfigManager::librariesAsVariant() const
+{
+    QVariantList list;
+    for (const SteamLibraryFolder &folder : m_libraries) {
+        QVariantMap map;
+        map[QStringLiteral("path")] = folder.path;
+        map[QStringLiteral("label")] = folder.label;
+        map[QStringLiteral("totalSize")] = folder.totalSize;
+        
+        QVariantList appIdList;
+        for (quint32 appId : folder.appIds) {
+            appIdList.append(appId);
+        }
+        map[QStringLiteral("appIds")] = appIdList;
+        
+        list.append(map);
+    }
+    return list;
+}
+
+QList<SteamLibraryFolder> SteamConfigManager::parseLibraryFoldersVdf(const QString &path)
+{
+    QList<SteamLibraryFolder> result;
+    
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qCWarning(couchplaySteam) << "Failed to open libraryfolders.vdf:" << path;
+        return result;
+    }
+    
+    QString content = QString::fromUtf8(file.readAll());
+    file.close();
+    
+    if (content.isEmpty()) {
+        return result;
+    }
+    
+    int pos = 0;
+    
+    auto skipWhitespace = [&]() {
+        while (pos < content.size() && content[pos].isSpace()) {
+            pos++;
+        }
+    };
+    
+    auto readToken = [&]() -> QString {
+        skipWhitespace();
+        if (pos >= content.size()) {
+            return QString();
+        }
+        
+        QChar c = content[pos];
+        if (c == QLatin1Char('{') || c == QLatin1Char('}')) {
+            pos++;
+            return QString(c);
+        }
+        if (c == QLatin1Char('"')) {
+            pos++;
+            QString token;
+            while (pos < content.size() && content[pos] != QLatin1Char('"')) {
+                token += content[pos];
+                pos++;
+            }
+            if (pos < content.size()) {
+                pos++;
+            }
+            return token;
+        }
+        
+        QString token;
+        while (pos < content.size() && !content[pos].isSpace()
+               && content[pos] != QLatin1Char('"')
+               && content[pos] != QLatin1Char('{')
+               && content[pos] != QLatin1Char('}')) {
+            token += content[pos];
+            pos++;
+        }
+        return token;
+    };
+    
+    QString rootKey = readToken();
+    if (rootKey != QStringLiteral("libraryfolders")) {
+        qCWarning(couchplaySteam) << "Unexpected root key in libraryfolders.vdf:" << rootKey;
+        return result;
+    }
+    
+    QString openBrace = readToken();
+    if (openBrace != QStringLiteral("{")) {
+        qCWarning(couchplaySteam) << "Expected { after libraryfolders key";
+        return result;
+    }
+    
+    while (pos < content.size()) {
+        skipWhitespace();
+        if (pos >= content.size()) {
+            break;
+        }
+        
+        QString indexKey = readToken();
+        if (indexKey.isEmpty() || indexKey == QStringLiteral("}")) {
+            break;
+        }
+        
+        QString entryBrace = readToken();
+        if (entryBrace != QStringLiteral("{")) {
+            break;
+        }
+        
+        SteamLibraryFolder folder;
+        
+        while (pos < content.size()) {
+            skipWhitespace();
+            if (pos >= content.size()) {
+                break;
+            }
+            
+            QString key = readToken();
+            if (key.isEmpty() || key == QStringLiteral("}")) {
+                break;
+            }
+            
+            if (key == QStringLiteral("apps")) {
+                QString appsBrace = readToken();
+                if (appsBrace != QStringLiteral("{")) {
+                    break;
+                }
+                
+                while (pos < content.size()) {
+                    QString appIdStr = readToken();
+                    if (appIdStr.isEmpty() || appIdStr == QStringLiteral("}")) {
+                        break;
+                    }
+                    
+                    bool ok;
+                    quint32 appId = appIdStr.toUInt(&ok);
+                    if (ok) {
+                        folder.appIds.append(appId);
+                    }
+                    
+                    readToken();
+                }
+                continue;
+            }
+            
+            QString value = readToken();
+            
+            if (key == QStringLiteral("path")) {
+                folder.path = value;
+            } else if (key == QStringLiteral("label")) {
+                folder.label = value;
+            } else if (key == QStringLiteral("totalsize")) {
+                folder.totalSize = value.toULongLong();
+            }
+        }
+        
+        if (!folder.path.isEmpty()) {
+            result.append(folder);
+        }
+    }
+    
+    return result;
+}
+
+QString SteamConfigManager::generateLibraryFoldersVdf(const QList<SteamLibraryFolder> &libraries)
+{
+    QString vdf;
+    vdf += QStringLiteral("\"libraryfolders\"\n{\n");
+    
+    for (int i = 0; i < libraries.size(); ++i) {
+        const SteamLibraryFolder &library = libraries[i];
+        vdf += QStringLiteral("\t\"%1\"\n\t{\n").arg(i);
+        vdf += QStringLiteral("\t\t\"path\"\t\t\"%1\"\n").arg(library.path);
+        vdf += QStringLiteral("\t\t\"label\"\t\t\"%1\"\n").arg(library.label);
+        vdf += QStringLiteral("\t\t\"contentid\"\t\t\"0\"\n");
+        vdf += QStringLiteral("\t\t\"totalsize\"\t\t\"%1\"\n").arg(library.totalSize);
+        
+        if (!library.appIds.isEmpty()) {
+            vdf += QStringLiteral("\t\t\"apps\"\n\t\t{\n");
+            for (quint32 appId : library.appIds) {
+                vdf += QStringLiteral("\t\t\t\"%1\"\t\t\"%1\"\n").arg(appId);
+            }
+            vdf += QStringLiteral("\t\t}\n");
+        }
+        
+        vdf += QStringLiteral("\t}\n");
+    }
+    
+    vdf += QStringLiteral("}\n");
+    return vdf;
+}
+
+bool SteamConfigManager::shareLibraryToUser(const QString &targetUsername)
+{
+    qCDebug(couchplaySteam) << "shareLibraryToUser called for" << targetUsername;
+    
+    if (!m_helperClient || !m_helperClient->isAvailable()) {
+        qCWarning(couchplaySteam) << "shareLibraryToUser failed - Helper not available";
+        return false;
+    }
+    
+    if (!m_steamPaths.valid) {
+        qCWarning(couchplaySteam) << "shareLibraryToUser failed - Steam not detected";
+        return false;
+    }
+    
+    if (m_libraries.isEmpty()) {
+        qCWarning(couchplaySteam) << "shareLibraryToUser failed - No libraries parsed, call loadLibraryFolders() first";
+        return false;
+    }
+    
+    SteamPaths targetPaths = getTargetSteamPaths(targetUsername);
+    if (!targetPaths.valid) {
+        qCWarning(couchplaySteam) << "shareLibraryToUser failed - Could not resolve target Steam paths for" << targetUsername;
+        return false;
+    }
+    
+    struct passwd *pw = getpwnam(targetUsername.toLocal8Bit().constData());
+    if (!pw) {
+        qCWarning(couchplaySteam) << "shareLibraryToUser failed - User not found:" << targetUsername;
+        return false;
+    }
+    QString targetHome = QString::fromLocal8Bit(pw->pw_dir);
+    
+    QString targetSteamId = getTargetSteamUserId(targetUsername);
+    if (targetSteamId.isEmpty()) {
+        qCWarning(couchplaySteam) << "shareLibraryToUser failed - Target user" << targetUsername
+                                   << "has not set up Steam (no userdata found). Launch Steam once first.";
+        Q_EMIT syncFailed(targetUsername, QStringLiteral("Target user has not set up Steam"));
+        return false;
+    }
+    
+    QStringList targetLibraryPaths;
+    QList<SteamLibraryFolder> targetLibraries;
+    bool anyFailure = false;
+    
+    for (int i = 0; i < m_libraries.size(); ++i) {
+        const SteamLibraryFolder &library = m_libraries[i];
+        
+        QString sourceCommon = library.path + QStringLiteral("/steamapps/common");
+        QString sourceSteamApps = library.path + QStringLiteral("/steamapps");
+        
+        QString targetLibPath;
+        if (i == 0) {
+            // Library 0 reuses the target's Steam root as the default install location
+            targetLibPath = targetPaths.steamRoot;
+        } else {
+            targetLibPath = targetHome + QStringLiteral("/.couchplay/steam-libs/") + QString::number(i);
+        }
+        
+        QString targetSteamApps = targetLibPath + QStringLiteral("/steamapps");
+        
+        qCDebug(couchplaySteam) << "Setting ACL on library" << library.path << "for" << targetUsername;
+        if (!m_helperClient->setPathAclWithParents(library.path, targetUsername)) {
+            qCWarning(couchplaySteam) << "Failed to set ACL on" << library.path;
+            anyFailure = true;
+        }
+        
+        // Mount spec "source|alias": empty alias (i==0) mounts at natural path,
+        // explicit alias (i>0) mounts into .couchplay/steam-libs/<i>/steamapps/common
+        QString mountSpec;
+        if (i == 0) {
+            mountSpec = sourceCommon + QStringLiteral("|");
+        } else {
+            mountSpec = sourceCommon + QStringLiteral("|/.couchplay/steam-libs/") + QString::number(i) + QStringLiteral("/steamapps/common");
+        }
+        
+        qCDebug(couchplaySteam) << "Mounting" << mountSpec << "for" << targetUsername;
+        int mountResult = m_helperClient->mountSharedDirectories(targetUsername, getuid(), {mountSpec});
+        if (mountResult <= 0) {
+            qCWarning(couchplaySteam) << "Failed to mount library" << i << "for" << targetUsername;
+            anyFailure = true;
+        }
+        
+        QDir sourceSteamAppsDir(sourceSteamApps);
+        QStringList manifests = sourceSteamAppsDir.entryList({QStringLiteral("appmanifest_*.acf")}, QDir::Files);
+        
+        for (const QString &manifest : manifests) {
+            QString manifestPath = sourceSteamApps + QLatin1Char('/') + manifest;
+            QFile manifestFile(manifestPath);
+            if (manifestFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                QByteArray content = manifestFile.readAll();
+                manifestFile.close();
+                
+                QString targetManifestPath = targetSteamApps + QLatin1Char('/') + manifest;
+                if (!m_helperClient->writeFileToUser(content, targetManifestPath, targetUsername)) {
+                    qCWarning(couchplaySteam) << "Failed to write manifest" << manifest << "for" << targetUsername;
+                    anyFailure = true;
+                }
+            }
+        }
+        
+        targetLibraryPaths.append(targetLibPath);
+        
+        // Target path + source metadata (app IDs, label, size) so Steam recognizes installed games
+        SteamLibraryFolder targetLib;
+        targetLib.path = targetLibPath;
+        targetLib.label = library.label;
+        targetLib.totalSize = library.totalSize;
+        targetLib.appIds = library.appIds;
+        targetLibraries.append(targetLib);
+    }
+    
+    QString vdfContent = generateLibraryFoldersVdf(targetLibraries);
+    
+    qCDebug(couchplaySteam) << "Writing libraryfolders.vdf to" << targetPaths.libraryFoldersVdf;
+    if (!m_helperClient->writeFileToUser(vdfContent.toUtf8(), targetPaths.libraryFoldersVdf, targetUsername)) {
+        qCWarning(couchplaySteam) << "Failed to write libraryfolders.vdf for" << targetUsername;
+        return false;
+    }
+    
+    if (anyFailure) {
+        qCWarning(couchplaySteam) << "Partially failed sharing Steam library to" << targetUsername;
+    } else {
+        qCDebug(couchplaySteam) << "Successfully shared" << m_libraries.size() << "Steam libraries to" << targetUsername;
+    }
+    
+    return !anyFailure;
+}
+
+void SteamConfigManager::cleanupLibrarySharing(const QString &targetUsername)
+{
+    if (!m_helperClient || !m_helperClient->isAvailable()) {
+        return;
+    }
+
+    SteamPaths targetPaths = getTargetSteamPaths(targetUsername);
+    if (!targetPaths.valid) {
+        return;
+    }
+
+    // Restore minimal libraryfolders.vdf — clears shared library entries
+    // so Steam doesn't reference bind-mounted paths that no longer exist.
+    QString emptyVdf = QStringLiteral("\"libraryfolders\"\n{\n}\n");
+    m_helperClient->writeFileToUser(emptyVdf.toUtf8(), targetPaths.libraryFoldersVdf, targetUsername);
+
+    qCDebug(couchplaySteam) << "Cleaned up library sharing for" << targetUsername;
 }

--- a/src/core/SteamConfigManager.h
+++ b/src/core/SteamConfigManager.h
@@ -70,6 +70,25 @@ public:
 Q_DECLARE_METATYPE(SteamShortcut)
 
 /**
+ * SteamLibraryFolder - Represents a Steam library folder
+ */
+struct SteamLibraryFolder {
+    Q_GADGET
+    Q_PROPERTY(QString path MEMBER path)
+    Q_PROPERTY(QString label MEMBER label)
+    Q_PROPERTY(quint64 totalSize MEMBER totalSize)
+    Q_PROPERTY(QList<quint32> appIds MEMBER appIds)
+
+public:
+    QString path;
+    QString label;
+    quint64 totalSize = 0;
+    QList<quint32> appIds;
+};
+
+Q_DECLARE_METATYPE(SteamLibraryFolder)
+
+/**
  * SteamConfigManager - Manages Steam configuration sharing between users
  *
  * Handles syncing shortcuts from the compositor user to gaming users
@@ -84,9 +103,11 @@ class SteamConfigManager : public QObject
     Q_PROPERTY(SteamPaths steamPaths READ steamPaths NOTIFY steamPathsChanged)
     Q_PROPERTY(bool steamDetected READ isSteamDetected NOTIFY steamPathsChanged)
     Q_PROPERTY(int shortcutCount READ shortcutCount NOTIFY shortcutsLoaded)
-    Q_PROPERTY(CouchPlayHelperClient *helperClient READ helperClient WRITE setHelperClient NOTIFY helperClientChanged)
-    Q_PROPERTY(bool syncShortcutsEnabled READ syncShortcutsEnabled WRITE setSyncShortcutsEnabled NOTIFY
-                   syncShortcutsEnabledChanged)
+    Q_PROPERTY(CouchPlayHelperClient* helperClient READ helperClient WRITE setHelperClient NOTIFY helperClientChanged)
+    Q_PROPERTY(bool syncShortcutsEnabled READ syncShortcutsEnabled WRITE setSyncShortcutsEnabled NOTIFY syncShortcutsEnabledChanged)
+    Q_PROPERTY(bool shareLibraryEnabled READ shareLibraryEnabled WRITE setShareLibraryEnabled NOTIFY shareLibraryEnabledChanged)
+    Q_PROPERTY(int libraryCount READ libraryCount NOTIFY librariesLoaded)
+    Q_PROPERTY(QVariantList libraries READ librariesAsVariant NOTIFY librariesLoaded)
 
 public:
     explicit SteamConfigManager(QObject *parent = nullptr);
@@ -134,6 +155,13 @@ public:
         return m_shortcuts.size();
     }
 
+    bool shareLibraryEnabled() const { return m_shareLibraryEnabled; }
+    void setShareLibraryEnabled(bool enabled);
+
+    int libraryCount() const { return m_libraries.size(); }
+
+    QVariantList librariesAsVariant() const;
+
     /**
      * Detect Steam installation paths
      */
@@ -157,6 +185,16 @@ public:
      * Load and parse shortcuts from the compositor's shortcuts.vdf
      */
     Q_INVOKABLE void loadShortcuts();
+
+    void loadLibraryFolders();
+
+    bool shareLibraryToUser(const QString &targetUsername);
+
+    /**
+     * Clean up library sharing state for a target user
+     * Removes copied manifests and restores original libraryfolders.vdf
+     */
+    void cleanupLibrarySharing(const QString &targetUsername);
 
     /**
      * Get shortcuts as QVariantList for QML
@@ -187,20 +225,26 @@ Q_SIGNALS:
     void shortcutsLoaded();
     void helperClientChanged();
     void syncShortcutsEnabledChanged();
+    void shareLibraryEnabledChanged();
+    void librariesLoaded();
     void syncCompleted(const QString &username);
     void syncFailed(const QString &username, const QString &error);
     void errorOccurred(const QString &message);
 
 private:
-    // VDF parsing
     QList<SteamShortcut> parseShortcutsVdf(const QString &path);
 
-    // Get target Steam paths for a user
+    QList<SteamLibraryFolder> parseLibraryFoldersVdf(const QString &path);
+
+    QString generateLibraryFoldersVdf(const QList<SteamLibraryFolder> &libraries);
+
     SteamPaths getTargetSteamPaths(const QString &username) const;
 
     CouchPlayHelperClient *m_helperClient = nullptr;
     SteamPaths m_steamPaths;
     QList<SteamShortcut> m_shortcuts;
+    QList<SteamLibraryFolder> m_libraries;
     QString m_userHome;
     bool m_syncShortcutsEnabled = false;
+    bool m_shareLibraryEnabled = false;
 };

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -342,6 +342,21 @@ Kirigami.ScrollablePage {
                 Controls.ToolTip.visible: hovered
                 Controls.ToolTip.delay: 1000
             }
+
+            Controls.CheckBox {
+                id: shareLibraryCheck
+                Kirigami.FormData.label: i18nc("@option:check", "Share game library with players:")
+                checked: root.steamConfigManager ? root.steamConfigManager.shareLibraryEnabled : false
+                onToggled: {
+                    if (root.steamConfigManager) {
+                        root.steamConfigManager.shareLibraryEnabled = checked
+                    }
+                }
+
+                Controls.ToolTip.text: i18nc("@info:tooltip", "Share your downloaded Steam games with gaming users via bind mounts. Each gaming user must own the game on their Steam account to play it. Disk space is saved because games are only downloaded once.")
+                Controls.ToolTip.visible: hovered
+                Controls.ToolTip.delay: 1000
+            }
         }
 
         Kirigami.FormLayout {
@@ -421,7 +436,7 @@ Kirigami.ScrollablePage {
             Layout.fillWidth: true
             visible: (root.steamConfigManager !== null && root.steamConfigManager.steamDetected) 
                       || (root.heroicConfigManager !== null && root.heroicConfigManager.heroicDetected)
-            text: i18nc("@info", "When sync is enabled, shortcuts are copied to gaming users at session start. Access to game directories is granted using filesystem ACLs.")
+            text: i18nc("@info", "When sync is enabled, shortcuts are copied to gaming users at session start. When library sharing is enabled, downloaded games are shared via bind mounts. Access to game directories is granted using filesystem ACLs.")
             type: Kirigami.MessageType.Information
         }
 


### PR DESCRIPTION
## Summary

- Add Steam library folder sharing so gaming users don't need to re-download games already installed by the compositor user
- Parse `libraryfolders.vdf` (text VDF format), mount `steamapps/common` via bind mounts, copy app manifests, and generate a target `libraryfolders.vdf` with full `apps` section so Steam recognizes installed games
- Add settings toggle in the Steam section of Settings page
- Gate on target user having launched Steam at least once (`getTargetSteamUserId` check)
- Clean up shared state on session stop (restore minimal `libraryfolders.vdf` after bind mounts are torn down)

## Changes

- **SteamConfigManager**: `SteamLibraryFolder` struct, `parseLibraryFoldersVdf`, `generateLibraryFoldersVdf` (with apps/label/totalsize), `shareLibraryToUser`, `cleanupLibrarySharing`, `loadLibraryFolders`
- **SessionRunner**: load library folders once before instance loop, call `shareLibraryToUser` per-instance, call `cleanupLibrarySharing` in `stop()`
- **SettingsPage**: "Share game library with players" checkbox with tooltip

## Technical details

- Library 0 maps to target's Steam root; additional libraries go to `~/.couchplay/steam-libs/<i>/`
- Mount specs use `"source|alias"` format via `CouchPlayHelperClient::mountSharedDirectories`
- ACLs set on source library paths via `setPathAclWithParents`
- Generated VDF includes `apps {}` block with all source app IDs so Steam shows games as installed