### PR TITLE
build: make PolkitQt6-1 a required dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
             kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
             kf6-kglobalaccel-devel extra-cmake-modules \
-            pipewire-devel polkit-devel
+            pipewire-devel polkit-devel polkit-qt6-1-devel
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
             kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
             kf6-kglobalaccel-devel extra-cmake-modules \
-            pipewire-devel polkit-devel
+            pipewire-devel polkit-devel polkit-qt6-1-devel
 
       - uses: actions/checkout@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,13 +49,9 @@ find_package(KF6 6.0 REQUIRED COMPONENTS
     GlobalAccel
 )
 
-# Find PolkitQt6-1 (optional — helper will deny user-management actions without it)
-find_package(PolkitQt6-1)
-if(NOT PolkitQt6-1_FOUND)
-    message(WARNING "PolkitQt6-1 not found: CouchPlay helper will compile WITHOUT Polkit "
-                     "authorization. User management actions will be denied. "
-                     "Install polkit-qt6-devel (or equivalent) to enable.")
-endif()
+# PolkitQt6-1 is required for user management authorization.
+# Without it the helper silently denies all user creation/deletion at runtime.
+find_package(PolkitQt6-1 REQUIRED)
 
 # Find QML modules at runtime
 ecm_find_qmlmodule(org.kde.kirigami REQUIRED)


### PR DESCRIPTION
## Summary

- Makes `PolkitQt6-1` a **required** CMake dependency instead of optional
- Adds `polkit-qt6-1-devel` to both CI and release workflow dependency lists

## Why

Polkit authorization was implemented in #9 but the dependency was marked optional. Without `polkit-qt6-devel` installed, the build silently produced a helper binary that denies all user creation/deletion actions at runtime. This change ensures the build fails early if the dependency is missing, and that CI actually tests with Polkit enabled.