### PR TITLE
fix(helper): fix service crash on non-immutable distros + add gamescope install check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,10 @@ ctest --test-dir build --output-on-failure
 
 ```
 ./
-├── src/core/       # 15 manager classes (30 files, ~10.5K lines) - SEE ./src/core/AGENTS.md
-├── src/qml/        # UI layer (pages + components) - SEE ./src/qml/AGENTS.md
-├── helper/         # Privileged D-Bus service (CouchPlayHelper.cpp 1945 lines) - SEE ./helper/AGENTS.md
-├── tests/          # QtTest unit tests (14 files, ~9.6K lines) - SEE ./tests/AGENTS.md
+├── src/core/       # 15 classes (30 files, ~9.3K lines) - SEE ./src/core/AGENTS.md
+├── src/qml/        # UI layer (17 files, ~4.3K lines) - SEE ./src/qml/AGENTS.md
+├── helper/         # Privileged D-Bus service (CouchPlayHelper.cpp 1960 lines) - SEE ./helper/AGENTS.md
+├── tests/          # QtTest unit tests (13 files, ~5.2K lines) - SEE ./tests/AGENTS.md
 ├── src/dbus/       # D-Bus client for helper service
 └── data/           # Icons, polkit policy, D-Bus service files
 ```
@@ -152,7 +152,7 @@ ctest --test-dir build --output-on-failure
 
 - **develop**: Main development branch, all PRs merge here
 - **main**: Stable releases only
-- **Feature branches**: Pattern `feature/<feature-name>`
+- **Branch prefixes**: `feature/`, `feat/`, `fix/`, `ci/`, `remove/` (e.g., `feature/steam-input`, `fix/ci-tests`)
 - **Releases**: Tag and release only from `main`, never from `develop`. Merge develop into main, tag, push.
 
 ## NOTES
@@ -161,10 +161,10 @@ ctest --test-dir build --output-on-failure
 - **Local docs**: `PLAN.md` has architecture overview and feature roadmap
 - **Build artifacts**: Ignore `build/` directory
 - **Root test files**: `test_*.cpp` are temporary/experimental, not part of test suite
-- **CI exclusions**: CI skips 7/14 tests requiring D-Bus/Polkit/devices (see `.github/workflows/ci.yml`)
+- **CI exclusions**: CI skips 7/13 tests requiring D-Bus/Polkit/devices (see `.github/workflows/ci.yml`)
 - **Linting**: `.clang-format` (WebKit-based, 120-char), `.clang-tidy` (pragmatic Qt6/C++20), `.editorconfig` present — run `make format` / `make tidy` locally
 
 ## GIT META
 
-- **Commit**: `8d9a171`
-- **Branch**: `fix/ui`
+- **Commit**: `521059b`
+- **Branch**: `develop`

--- a/data/dbus/couchplay-helper.service
+++ b/data/dbus/couchplay-helper.service
@@ -29,7 +29,7 @@ MemoryDenyWriteExecute=true
 ReadWritePaths=/dev/input
 # Allow access to user home directories for PipeWire config
 ReadWritePaths=/home
-ReadWritePaths=/var/home
+ReadWritePaths=-/var/home
 # Allow access to /etc for user creation (useradd needs to modify passwd, group, shadow)
 ReadWritePaths=/etc
 

--- a/helper/AGENTS.md
+++ b/helper/AGENTS.md
@@ -2,13 +2,13 @@
 
 ## OVERVIEW
 
-D-Bus privileged service for split-screen gaming: user creation, device ownership, IPC orchestration, state persistence (2 files, 2320 lines)
+D-Bus privileged service for split-screen gaming: user creation, device ownership, IPC orchestration, state persistence (7 files, ~2.7K lines)
 
 ## STRUCTURE
 
-**CouchPlayHelper.cpp (1945 lines):** Main service implementation — partial Polkit authorization (user lifecycle only), D-Bus slots, systemd-run transient unit spawning, device ownership, mount management, state persistence, runtime ACL cache verification, dynamic gamescope path resolution
+**CouchPlayHelper.cpp (1960 lines):** Main service implementation — partial Polkit authorization (user lifecycle only), D-Bus slots, systemd-run transient unit spawning, device ownership, mount management, state persistence, runtime ACL cache verification, dynamic gamescope path resolution
 
-**CouchPlayHelper.h (375 lines):** D-Bus interface definition — 18 Q_SLOT methods exposed via io.github.hikaps.CouchPlayHelper
+**CouchPlayHelper.h (373 lines):** D-Bus interface definition — 18 Q_SLOT methods exposed via io.github.hikaps.CouchPlayHelper
 
 **SystemOps.h/cpp:** Abstraction layer for system calls (getpwnam, chown, mount, etc.) — enables mocking in tests. `RealSystemOps::checkAuthorization()` implements Polkit for `ACTION_CREATE_USER` and `ACTION_DELETE_USER` only; other actions return `true` (D-Bus ACL enforced at bus level)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,6 +103,20 @@ check_dependencies() {
         echo "  sudo pacman -S ${missing_deps[*]}"
         exit 1
     fi
+
+    # Check for runtime dependencies (warn but don't fail)
+    if ! command -v gamescope &>/dev/null; then
+        print_warn "gamescope is not installed. CouchPlay requires gamescope to launch game sessions."
+        echo ""
+        echo "On Debian/Ubuntu:"
+        echo "  sudo apt install gamescope"
+        echo ""
+        echo "On Fedora:"
+        echo "  sudo dnf install gamescope"
+        echo ""
+        echo "On Arch Linux:"
+        echo "  sudo pacman -S gamescope"
+    fi
 }
 
 check_architecture() {

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -5,21 +5,21 @@ Core business logic layer: device management, session orchestration, user/monito
 
 ## STRUCTURE
 **15 Manager Classes:**
-- `SessionRunner` (~1288 lines) - Orchestrates multiple GamescopeInstance launches (6-phase startup)
-- `DeviceManager` (~998 lines) - Input device detection from /proc/bus/input/devices, hotplug state machine
-- `SteamConfigManager` (599 lines) - VDF parsing, shortcuts syncing
-- `HeroicConfigManager` (621 lines) - Heroic launcher config management (Legendary/GOG/Nile)
-- `PresetManager` (526 lines) - Launch preset profiles, .desktop scanning
+- `SessionRunner` (1310 lines) - Orchestrates multiple GamescopeInstance launches (6-phase startup)
+- `DeviceManager` (998 lines) - Input device detection from /proc/bus/input/devices, hotplug state machine
+- `SteamConfigManager` (987 lines) - VDF parsing, shortcuts syncing
+- `HeroicConfigManager` (616 lines) - Heroic launcher config management (Legendary/GOG/Nile)
+- `PresetManager` (631 lines) - Launch preset profiles, .desktop scanning
 - `SessionManager` (550 lines) - Session profiles, instance configuration
 - `WindowManager` (448 lines) - Window positioning via KWin (QML_SINGLETON)
-- `GamescopeInstance` (~380 lines) - Gamescope arg building, delegates execution to D-Bus helper
+- `GamescopeInstance` (337 lines) - Gamescope arg building, delegates execution to D-Bus helper
 - `UserManager` (251 lines) - Linux user creation/management
-- `AudioManager` (~100 lines) - PipeWire/PulseAudio audio routing and socket ACL checks
-- `SettingsManager` (~150 lines) - KConfig-based app settings
-- `MonitorManager` (~50 lines) - Display detection via QGuiApplication screens
-- `VirtualDeviceWatcher` (~150 lines) - Virtual device monitoring during sessions
-- `CommandVerifier` (~200 lines) - Static utility: command validation, Flatpak detection, PATH resolution
-- `Logging` (39 lines) - 6 scoped logging categories
+- `CommandVerifier` (340 lines) - Static utility: command validation, Flatpak detection, PATH resolution
+- `SettingsManager` (177 lines) - KConfig-based app settings
+- `VirtualDeviceWatcher` (146 lines) - Virtual device monitoring during sessions
+- `AudioManager` (103 lines) - PipeWire/PulseAudio audio routing and socket ACL checks
+- `MonitorManager` (67 lines) - Display detection via QGuiApplication screens
+- `Logging` (14 lines) - 6 scoped logging categories
 
 **Data Structures:** `InputDevice`, `InstanceConfig`, `SessionProfile`, `SteamPaths`, `SteamShortcut` (Q_GADGET structs)
 

--- a/src/qml/AGENTS.md
+++ b/src/qml/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## OVERVIEW
 
-QML/Kirigami UI layer: 17 files (~3.7K lines), 6 pages, 5 components, 5 dialogs.
+QML/Kirigami UI layer: 17 files (~4.3K lines), 6 pages, 5 components, 5 dialogs.
 
 ## STRUCTURE
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,24 +1,24 @@
 # AGENTS.md - Test Guidelines for CouchPlay
 
-QtTest unit test suite for core manager components (13 test files, ~9.6K lines).
+QtTest unit test suite for core manager components (13 test files, ~5.2K lines).
 
 ## STRUCTURE
 
 | Test File | Test Class | Lines | Focus |
 |-----------|-------------|-------|-------|
-| test_devicemanager.cpp | DeviceManagerTest | 671 | Device detection, assignment, stable IDs |
-| test_gamescopeinstance.cpp | GamescopeInstanceTest | 446 | Process wrapping, arg building |
-| test_presetmanager.cpp | PresetManagerTest | 479 | Built-in/custom presets, app scanning |
-| test_sessionmanager.cpp | SessionManagerTest | 364 | Session profiles, layout configs |
+| test_couchplayhelper.cpp | CouchPlayHelperTest | 1501 | Helper service (MockSystemOps, 25 overrides) |
+| test_devicemanager.cpp | DeviceManagerTest | 664 | Device detection, assignment, stable IDs |
+| test_heroicconfigmanager.cpp | HeroicConfigManagerTest | 468 | Heroic config parsing (Legendary/GOG/Nile) |
+| test_gamescopeinstance.cpp | GamescopeInstanceTest | 444 | Process wrapping, arg building |
 | test_usermanager.cpp | UserManagerTest | 363 | User creation, D-Bus mocking |
-| test_heroicconfigmanager.cpp | HeroicConfigManagerTest | 340 | Heroic config parsing (Legendary/GOG/Nile) |
+| test_sessionmanager.cpp | SessionManagerTest | 330 | Session profiles, layout configs |
+| test_sessionrunner.cpp | SessionRunnerTest | 328 | Instance orchestration, mock D-Bus client |
+| test_presetmanager.cpp | PresetManagerTest | 245 | Built-in/custom presets, app scanning |
+| test_presetmanager_integration.cpp | PresetManagerIntegrationTest | 242 | End-to-end preset + app scanning |
+| test_audiomanager.cpp | TestAudioManager | 204 | PipeWire/PulseAudio detection, socket ACL checking |
 | test_monitormanager.cpp | MonitorManagerTest | 166 | Display detection |
-| test_commandverifier.cpp | CommandVerifierTest | 102 | Path validation, flatpak detection |
-| test_scanapplications.cpp | ScanApplicationsTest | 65 | .desktop file scanning |
-| test_audiomanager.cpp | TestAudioManager | 217 | PipeWire/PulseAudio detection, socket ACL checking |
-| test_couchplayhelper.cpp | CouchPlayHelperTest | 1655 | Helper service (MockSystemOps, 25 overrides) |
-| test_sessionrunner.cpp | SessionRunnerTest | 382 | Instance orchestration, mock D-Bus client |
-| test_presetmanager_integration.cpp | PresetManagerIntegrationTest | 243 | End-to-end preset + app scanning |
+| test_commandverifier.cpp | CommandVerifierTest | 139 | Path validation, flatpak detection |
+| test_scanapplications.cpp | ScanApplicationsTest | 66 | .desktop file scanning |
 
 ## WHERE TO LOOK
 
@@ -77,5 +77,5 @@ class MockCouchPlayHelperClient : public CouchPlayHelperClient {
 - **Flaky environment tests**: Desktop files or installed flatpaks may not exist
 - **D-Bus dependency**: `UserManagerTest` requires helper service running
 - **CI exclusions**: 7/13 tests skipped (D-Bus/Polkit/devices) - see `.github/workflows/ci.yml`
-- **Partial coverage**: SessionRunner lacks dedicated tests
+- **Partial coverage**: Some managers lack dedicated tests
 - **Private member access**: `#define private public` / `#undef private` around includes (test_sessionrunner.cpp, test_audiomanager.cpp)


### PR DESCRIPTION
## Summary

- Make `/var/home` optional in the systemd unit's `ReadWritePaths` by prefixing with `-`, so `couchplay-helper.service` does not fail to start on non-immutable distros (e.g. standard Fedora Workstation) where `/var/home` does not exist
- Add a soft warning for missing `gamescope` in the one-liner installer's dependency checks, so users are alerted before their first session launch rather than after

Closes #18

## Changes

**`data/dbus/couchplay-helper.service`**
- `ReadWritePaths=/var/home` → `ReadWritePaths=-/var/home`

**`scripts/install.sh`**
- Add `gamescope` runtime dependency check (warns with per-distro install instructions, does not block installation)