### PR TITLE
fix: user creation fails on Bazzite (input group missing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ qrc_*.cpp
 # Documentation (kept in docs/branches/ only)
 .sisyphus
 .opencode
+.omo
 compile_commands.json
 .cache/

--- a/helper/CouchPlayHelper.cpp
+++ b/helper/CouchPlayHelper.cpp
@@ -329,7 +329,12 @@ uint CouchPlayHelper::CreateUser(const QString &username, const QString &fullNam
     args << QStringLiteral("-m") << QStringLiteral("-c") << fullName << QStringLiteral("-s")
          << QStringLiteral("/bin/bash");
 
-    args << QStringLiteral("-G") << QStringLiteral("input,") + COUCHPLAY_GROUP;
+    // "input" group is optional (absent on Bazzite); omit if missing to avoid useradd failure (issue #23)
+    QString supplementaryGroups = COUCHPLAY_GROUP;
+    if (m_ops->getgrnam("input")) {
+        supplementaryGroups = QStringLiteral("input,") + COUCHPLAY_GROUP;
+    }
+    args << QStringLiteral("-G") << supplementaryGroups;
 
     args << username;
 

--- a/tests/test_couchplayhelper.cpp
+++ b/tests/test_couchplayhelper.cpp
@@ -351,6 +351,8 @@ private Q_SLOTS:
     void testCreateUserAuthDenied();
     void testCreateUserProcessFailure();
     void testCreateUserLingerFailure();
+    void testCreateUserWithoutInputGroup();
+    void testCreateUserWithInputGroup();
     void testDeleteUserSuccess();
     void testDeleteUserInvalidUsername();
     void testDeleteUserNonexistent();
@@ -568,6 +570,54 @@ void TestCouchPlayHelper::testCreateUserLingerFailure()
 
     QVERIFY(!reply.isValid());
     QCOMPARE(reply.error().type(), QDBusError::Failed);
+}
+
+void TestCouchPlayHelper::testCreateUserWithoutInputGroup()
+{
+    // "input" group absent (simulates Bazzite) — must not appear in -G
+    m_ops->clear();
+    m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001, {});
+    m_ops->setProcessExitCode(0);
+
+    m_dbusInterface->call(QStringLiteral("CreateUser"), QStringLiteral("newuser"), QStringLiteral("New User"));
+
+    QStringList useraddArgs;
+    for (const auto &inv : m_ops->m_processInvocations) {
+        if (inv.command == QStringLiteral("useradd")) {
+            useraddArgs = inv.args;
+            break;
+        }
+    }
+    QVERIFY(!useraddArgs.isEmpty());
+
+    int gIdx = useraddArgs.indexOf(QStringLiteral("-G"));
+    QVERIFY(gIdx >= 0);
+    QVERIFY(gIdx + 1 < useraddArgs.size());
+    QCOMPARE(useraddArgs.at(gIdx + 1), QStringLiteral("couchplay"));
+}
+
+void TestCouchPlayHelper::testCreateUserWithInputGroup()
+{
+    m_ops->clear();
+    m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001, {});
+    m_ops->setGroupExists(QStringLiteral("input"), true, 44, {});
+    m_ops->setProcessExitCode(0);
+
+    m_dbusInterface->call(QStringLiteral("CreateUser"), QStringLiteral("newuser"), QStringLiteral("New User"));
+
+    QStringList useraddArgs;
+    for (const auto &inv : m_ops->m_processInvocations) {
+        if (inv.command == QStringLiteral("useradd")) {
+            useraddArgs = inv.args;
+            break;
+        }
+    }
+    QVERIFY(!useraddArgs.isEmpty());
+
+    int gIdx = useraddArgs.indexOf(QStringLiteral("-G"));
+    QVERIFY(gIdx >= 0);
+    QVERIFY(gIdx + 1 < useraddArgs.size());
+    QCOMPARE(useraddArgs.at(gIdx + 1), QStringLiteral("input,couchplay"));
 }
 
 void TestCouchPlayHelper::testDeleteUserSuccess()

--- a/tests/test_sessionmanager.cpp
+++ b/tests/test_sessionmanager.cpp
@@ -35,6 +35,8 @@ private Q_SLOTS:
     void testGetInstanceConfig();
     void testSetInstanceConfig();
     void testSetInstanceResolution();
+    void testRecalculateOutputResolutionsHorizontal();
+    void testRecalculateOutputResolutionsVertical();
     void testSetInstanceUser();
 
     // Profile management tests
@@ -168,6 +170,37 @@ void TestSessionManager::testSetInstanceResolution()
     QCOMPARE(config.value(KEY("internalHeight")).toInt(), 1440);
     QCOMPARE(config.value(KEY("outputWidth")).toInt(), 1920);
     QCOMPARE(config.value(KEY("outputHeight")).toInt(), 1080);
+}
+
+void TestSessionManager::testRecalculateOutputResolutionsHorizontal()
+{
+    // Internal matches output so the game adapts its UI to the split-screen aspect ratio
+    m_sessionManager->setInstanceCount(2);
+    m_sessionManager->setCurrentLayout(QStringLiteral("horizontal"));
+
+    QSignalSpy spy(m_sessionManager, &SessionManager::instancesChanged);
+    m_sessionManager->recalculateOutputResolutions(1920, 1080);
+    QVERIFY(spy.count() >= 1);
+
+    QVariantMap config0 = m_sessionManager->getInstanceConfig(0);
+    QCOMPARE(config0.value(KEY("outputWidth")).toInt(), 960);
+    QCOMPARE(config0.value(KEY("outputHeight")).toInt(), 1080);
+    QCOMPARE(config0.value(KEY("internalWidth")).toInt(), 960);
+    QCOMPARE(config0.value(KEY("internalHeight")).toInt(), 1080);
+}
+
+void TestSessionManager::testRecalculateOutputResolutionsVertical()
+{
+    m_sessionManager->setInstanceCount(2);
+    m_sessionManager->setCurrentLayout(QStringLiteral("vertical"));
+
+    m_sessionManager->recalculateOutputResolutions(1920, 1080);
+
+    QVariantMap config0 = m_sessionManager->getInstanceConfig(0);
+    QCOMPARE(config0.value(KEY("outputWidth")).toInt(), 1920);
+    QCOMPARE(config0.value(KEY("outputHeight")).toInt(), 540);
+    QCOMPARE(config0.value(KEY("internalWidth")).toInt(), 1920);
+    QCOMPARE(config0.value(KEY("internalHeight")).toInt(), 540);
 }
 
 void TestSessionManager::testSetInstanceUser()


### PR DESCRIPTION
## Summary

Fixes the user creation bug reported in #23.

### `useradd: group input does not exist`

`CreateUser()` in `helper/CouchPlayHelper.cpp` unconditionally passed `-G input,couchplay` to `useradd`. The `input` group does **not** exist by default on Bazzite / Fedora Silverblue-based immutable images, which makes `useradd` abort with `group input does not exist` — blocking user creation entirely.

**Fix:** Probe `getgrnam("input")` before including it in the supplementary groups list. Only includes `input` if it exists; always includes `couchplay`. This matches the existing pattern already used in `ChangeDeviceOwner()` / `ResetDeviceOwner()`.

Device access is **unaffected** — it works via `chown` ownership transfer, not group membership.

## Changes

| File | Change |
|------|--------|
| `helper/CouchPlayHelper.cpp` | Probe `input` group existence before `-G`; omit if absent |
| `tests/test_couchplayhelper.cpp` | +2 tests |
| `tests/test_sessionmanager.cpp` | +2 tests |

## Verification

All 4 new tests pass. 3 pre-existing environmental failures confirmed unchanged by stash/rebuild on clean `develop`.

## Note on resolution

The current behavior (internal = output = split-screen size) is **intentional** — games adapt their UI to the split-screen aspect ratio. Setting internal to native would cause aspect ratio mismatches.

## Note on Steam not launching

The reporter created users manually, bypassing home directory creation and linger. Once this fix lands, creating users through the app handles all of that automatically.

Closes #23.