### PR TITLE
ci: add beta release channel from develop

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,87 @@
+name: Beta Release
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  beta:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:41
+    steps:
+      - name: Install dependencies
+        run: |
+          dnf install -y cmake gcc-c++ git make tar \
+            qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qt5compat-devel \
+            kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
+            kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
+            kf6-kglobalaccel-devel extra-cmake-modules \
+            pipewire-devel polkit-devel polkit-qt6-1-devel
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory /__w/couchplay/couchplay
+
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build build --parallel 2
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure -E "test_usermanager|test_couchplayhelper|test_gamescopeinstance|test_presetmanager_integration|test_commandverifier|test_devicemanager|test_heroicconfigmanager"
+        env:
+          QT_QPA_PLATFORM: offscreen
+
+      - name: Package
+        run: |
+          mkdir -p release-appdir/bin
+          mkdir -p release-appdir/data
+
+          # Copy binaries
+          cp build/bin/couchplay release-appdir/bin/
+          cp build/bin/couchplay-helper release-appdir/bin/
+
+          # Copy scripts
+          cp scripts/install-helper.sh release-appdir/
+          chmod +x release-appdir/install-helper.sh
+
+          # Copy data
+          cp -r data/* release-appdir/data/
+
+          # Create tarball
+          tar -cJf couchplay-x86_64.tar.xz -C release-appdir .
+
+      - name: Generate checksum
+        run: sha256sum couchplay-x86_64.tar.xz > couchplay-x86_64.sha256
+
+      - name: Generate release notes
+        run: |
+          echo "Latest build from **develop** branch." > body.md
+          echo "" >> body.md
+          echo "Commit: ${{ github.sha }}" >> body.md
+          echo "" >> body.md
+          echo "### Recent changes" >> body.md
+          git log --oneline -10 >> body.md
+          echo "" >> body.md
+          echo "> ⚠️ This is a pre-release build for testing. Not for production use." >> body.md
+
+      - name: Create beta release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: beta
+          name: "Beta (from develop)"
+          body_path: body.md
+          prerelease: true
+          make_latest: false
+          files: |
+            couchplay-x86_64.tar.xz
+            couchplay-x86_64.sha256

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/insta
 
 > **Requirements**: Linux x86_64, root privileges (sudo). This downloads and installs the latest release from GitHub, including the privileged helper service.
 
+### Beta (from develop)
+
+Install the latest build from the `develop` branch:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --beta
+```
+
+> **Warning**: Beta builds include unreleased features and may be unstable. For production use, install the stable release above.
+
 ## Installation (Bazzite / Fedora Atomic)
 
 CouchPlay uses a privileged helper to manage devices and users.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,8 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash
-#   sudo ./install.sh
+#   curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --beta
+#   sudo ./install.sh --beta
 #
 # Requirements:
 #   - curl: for downloading files
@@ -169,6 +170,36 @@ get_latest_release() {
         exit 1
     fi
     
+    echo "$response"
+}
+
+get_beta_release() {
+    # Fetches the beta (pre-release) metadata from GitHub Releases API
+    # Uses the /releases/tags/beta endpoint to get the rolling beta release
+    # Returns JSON with: tag_name, name, assets[], etc.
+
+    local api_url="${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/releases/tags/beta"
+    local response
+    local http_code
+
+    print_info "Fetching beta release information..."
+
+    response=$(curl -sL -w "\n%{http_code}" "$api_url" 2>/dev/null)
+    http_code=$(echo "$response" | tail -n1)
+    response=$(echo "$response" | sed '$d')
+
+    if [[ "$http_code" != "200" ]]; then
+        print_error "Failed to fetch beta release information (HTTP $http_code)"
+        echo ""
+        echo "This could mean:"
+        echo "  - No beta release has been published yet"
+        echo "  - GitHub API rate limit exceeded"
+        echo "  - Network connectivity issues"
+        echo ""
+        echo "Please check: https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/beta"
+        exit 1
+    fi
+
     echo "$response"
 }
 
@@ -399,6 +430,14 @@ cleanup() {
 # =============================================================================
 
 main() {
+    local BETA=false
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --beta) BETA=true; shift ;;
+            *) shift ;;
+        esac
+    done
+
     print_info "CouchPlay Installer"
     echo ""
     
@@ -409,9 +448,14 @@ main() {
     
     echo ""
     
-    # Get latest release info
+    # Get release info (beta or stable)
     local release_json
-    release_json=$(get_latest_release)
+    if $BETA; then
+        release_json=$(get_beta_release)
+        print_warn "Installing BETA build from develop — not a stable release!"
+    else
+        release_json=$(get_latest_release)
+    fi
     
     local tag_name
     tag_name=$(get_release_tag "$release_json")


### PR DESCRIPTION
## Summary

Adds a beta release channel so users can test fixes and unreleased features from `develop` without waiting for a stable release.

### Changes

**`.github/workflows/beta.yml`** (new)
- Triggers on push to `develop` + manual `workflow_dispatch`
- Builds in Fedora 41 (same as `release.yml`), runs tests, packages tarball + checksum
- Creates/updates a rolling pre-release tagged `beta` via `softprops/action-gh-release@v2`
- `prerelease: true` + `make_latest: false` — invisible to `/releases/latest`

**`scripts/install.sh`**
- `--beta` flag: fetches from `/releases/tags/beta` instead of `/releases/latest`
- Prints a warning when installing beta
- Stable path unchanged

```bash
# Stable (unchanged)
curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash

# Beta
curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --beta
```

**`README.md`**
- Documents the beta install option

## Verification

- `bash -n scripts/install.sh` — syntax OK
- `python3 yaml.safe_load(beta.yml)` — YAML valid
- `--beta` flag parsing tested in isolation (sets `BETA=true`, default `false`)
- CI will verify on merge: workflow builds, tests pass, beta pre-release created
- After merge: `gh release view beta` should show pre-release with assets
- Stable unaffected: `/releases/latest` still returns `v0.3.4` (pre-releases excluded)