### PR TITLE
fix(install): robust D-Bus reload + correct Flatpak helper export path (#28)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
             kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
             kf6-kglobalaccel-devel extra-cmake-modules \
-            pipewire-devel polkit-devel polkit-qt6-1-devel
+            pipewire-devel polkit-devel polkit-qt6-1-devel patchelf
 
       - uses: actions/checkout@v4
         with:
@@ -59,6 +59,10 @@ jobs:
           # Copy binaries
           cp build/bin/couchplay release-appdir/bin/
           cp build/bin/couchplay-helper release-appdir/bin/
+
+          # Bundle the helper's runtime libraries so it runs without system Qt6/Polkit
+          chmod +x scripts/bundle-libs.sh
+          ./scripts/bundle-libs.sh release-appdir/bin/couchplay-helper lib/couchplay
 
           # Copy scripts
           cp scripts/install-helper.sh release-appdir/

--- a/README.md
+++ b/README.md
@@ -67,51 +67,22 @@ The **Settings** page offers additional configuration:
 - **Scaling and filter modes** — per-instance rendering options.
 - **Steam and Heroic shortcut sync** — keep launch shortcuts in sync across users.
 
-## Quick Install (Linux x86_64)
+## Installation
 
-Install the latest release with a single command:
+CouchPlay needs a small privileged helper (a root systemd/D-Bus service) to manage
+input devices, users, and audio — so every method below includes a one-time helper
+install. Pick the one that fits your system:
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash
-```
+| Method | Best for |
+|---|---|
+| **Flatpak** | Most users — runs on any distro with Flatpak; no system Qt6/KF6 needed. |
+| **Tarball** (curl one-liner or manual) | Immutable/atomic distros (Bazzite, Silverblue), traditional distros, packagers. Installs into `/usr/local`. |
+| **AppImage** | Try it instantly / portable GUI (Qt6/KF6 bundled inside). |
 
-> **Requirements**: Linux x86_64, root privileges (sudo). This downloads and installs the latest release from GitHub, including the privileged helper service.
+> The helper service is installed the same way regardless of method; only how the GUI
+> is delivered differs.
 
-### Beta (from develop)
-
-Install the latest build from the `develop` branch:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --beta
-```
-
-> **Warning**: Beta builds include unreleased features and may be unstable. For production use, install the stable release above.
-
-## Installation (Bazzite / Fedora Atomic)
-
-CouchPlay uses a privileged helper to manage devices and users.
-
-1. **Download** the latest release tarball from the [Releases page](../../releases).
-2. **Extract** the archive:
-   ```bash
-   tar -xJf couchplay-x86_64.tar.xz
-   cd couchplay-x86_64
-   ```
-3. **Install** the helper service (requires sudo):
-   ```bash
-   sudo ./install-helper.sh install
-   ```
-4. **Run** the application:
-   ```bash
-   ./bin/couchplay
-   ```
-
-### Uninstallation
-```bash
-sudo ./install-helper.sh uninstall
-```
-
-## Flatpak Installation
+### Flatpak Installation
 
 1. **Download** the `.flatpak` bundle from the [Releases page](../../releases).
 2. **Ensure the runtime is available** (Flathub provides org.kde.Platform 6.10):
@@ -127,16 +98,71 @@ sudo ./install-helper.sh uninstall
    flatpak run --command=bash io.github.hikaps.couchplay -c "/app/share/couchplay/install-helper.sh export"
    sudo ~/.var/app/io.github.hikaps.couchplay/data/couchplay/install-helper.sh install
    ```
-
    The `export` step stages the helper in the Flatpak's persisted data directory
-   (`~/.var/app/io.github.hikaps.couchplay/data/couchplay`), which is visible on your host
-   at the same path. The second command installs it system-wide from there.
+   (`~/.var/app/io.github.hikaps.couchplay/data/couchplay`), visible on your host at the
+   same path; the second command installs it system-wide from there.
 
-   > On **older Flatpak builds** (before this fix), `export` wrote to the sandbox home and
-   > the files never reached the host — the second command would find nothing. Update to the
-   > latest release, or use the tarball install method instead.
+### Tarball Installation
 
-> **Note**: The tarball installation method above is also available if you prefer it or your distribution doesn't support Flatpak.
+For immutable/atomic distros (Bazzite, Fedora Silverblue/Kinoite) and traditional
+distros. Installs into `/usr/local` and registers the helper service. The release
+bundles the helper's runtime libraries, so the helper starts without system Qt6.
+
+**One-liner (stable):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash
+```
+> Requires Linux x86_64 and sudo.
+
+**Beta (from develop):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --beta
+```
+> Beta builds include unreleased features and may be unstable.
+
+**Manual (download + extract):**
+1. **Download** the latest release tarball from the [Releases page](../../releases).
+2. **Extract**:
+   ```bash
+   tar -xJf couchplay-x86_64.tar.xz
+   cd couchplay-x86_64
+   ```
+3. **Install** the helper service (requires sudo):
+   ```bash
+   sudo ./install-helper.sh install
+   ```
+4. **Run**:
+   ```bash
+   ./bin/couchplay
+   ```
+
+**Uninstall:**
+```bash
+sudo ./install-helper.sh uninstall
+```
+
+### AppImage Installation
+
+A portable single file: the GUI is bundled with its Qt6/KF6 runtime libraries, so it runs
+on most current x86_64 desktops (Arch, Fedora, Ubuntu 24.04 LTS, Debian 13 and newer)
+without installing Qt6/KF6 system-wide.
+
+1. **Download** `CouchPlay-x86_64.AppImage` from the [Releases page](../../releases).
+2. **Make it executable** and **launch the GUI**:
+   ```bash
+   chmod +x CouchPlay-x86_64.AppImage
+   ./CouchPlay-x86_64.AppImage
+   ```
+3. **Install the helper service** (required for device management — it runs from system
+   paths, not the AppImage):
+   ```bash
+   ./CouchPlay-x86_64.AppImage install-helper
+   ```
+   This extracts the helper and runs `install-helper.sh install` with `sudo`.
+
+> **Portability note**: the AppImage's compatibility floor is the glibc it was built
+> against (currently glibc 2.39). It won't run on older LTS releases (Debian 12, Ubuntu
+> 22.04 LTS); use Flatpak or the tarball there.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -125,17 +125,16 @@ sudo ./install-helper.sh uninstall
 4. **Install the helper service** (required for device management):
    ```bash
    flatpak run --command=bash io.github.hikaps.couchplay -c "/app/share/couchplay/install-helper.sh export"
-   sudo ~/.local/share/couchplay/install-helper.sh install
+   sudo ~/.var/app/io.github.hikaps.couchplay/data/couchplay/install-helper.sh install
    ```
 
-   The `export` step copies the helper and install script to `~/.local/share/couchplay`
-   on your host (this requires the `--filesystem=home` permission, included in current
-   builds). If you are on an **older Flatpak build** where `export` produced no files in
-   `~/.local/share/couchplay`, the files were written to the Flatpak sandbox home instead —
-   install from there:
-   ```bash
-   sudo ~/.var/app/io.github.hikaps.couchplay/.local/share/couchplay/install-helper.sh install
-   ```
+   The `export` step stages the helper in the Flatpak's persisted data directory
+   (`~/.var/app/io.github.hikaps.couchplay/data/couchplay`), which is visible on your host
+   at the same path. The second command installs it system-wide from there.
+
+   > On **older Flatpak builds** (before this fix), `export` wrote to the sandbox home and
+   > the files never reached the host — the second command would find nothing. Update to the
+   > latest release, or use the tarball install method instead.
 
 > **Note**: The tarball installation method above is also available if you prefer it or your distribution doesn't support Flatpak.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ sudo ./install-helper.sh uninstall
    sudo ~/.local/share/couchplay/install-helper.sh install
    ```
 
+   The `export` step copies the helper and install script to `~/.local/share/couchplay`
+   on your host (this requires the `--filesystem=home` permission, included in current
+   builds). If you are on an **older Flatpak build** where `export` produced no files in
+   `~/.local/share/couchplay`, the files were written to the Flatpak sandbox home instead —
+   install from there:
+   ```bash
+   sudo ~/.var/app/io.github.hikaps.couchplay/.local/share/couchplay/install-helper.sh install
+   ```
+
 > **Note**: The tarball installation method above is also available if you prefer it or your distribution doesn't support Flatpak.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ install. Pick the one that fits your system:
 |---|---|
 | **Flatpak** | Most users — runs on any distro with Flatpak; no system Qt6/KF6 needed. |
 | **Tarball** (curl one-liner or manual) | Immutable/atomic distros (Bazzite, Silverblue), traditional distros, packagers. Installs into `/usr/local`. |
-| **AppImage** | Try it instantly / portable GUI (Qt6/KF6 bundled inside). |
 
 > The helper service is installed the same way regardless of method; only how the GUI
 > is delivered differs.
@@ -140,29 +139,6 @@ curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/insta
 ```bash
 sudo ./install-helper.sh uninstall
 ```
-
-### AppImage Installation
-
-A portable single file: the GUI is bundled with its Qt6/KF6 runtime libraries, so it runs
-on most current x86_64 desktops (Arch, Fedora, Ubuntu 24.04 LTS, Debian 13 and newer)
-without installing Qt6/KF6 system-wide.
-
-1. **Download** `CouchPlay-x86_64.AppImage` from the [Releases page](../../releases).
-2. **Make it executable** and **launch the GUI**:
-   ```bash
-   chmod +x CouchPlay-x86_64.AppImage
-   ./CouchPlay-x86_64.AppImage
-   ```
-3. **Install the helper service** (required for device management — it runs from system
-   paths, not the AppImage):
-   ```bash
-   ./CouchPlay-x86_64.AppImage install-helper
-   ```
-   This extracts the helper and runs `install-helper.sh install` with `sudo`.
-
-> **Portability note**: the AppImage's compatibility floor is the glibc it was built
-> against (currently glibc 2.39). It won't run on older LTS releases (Debian 12, Ubuntu
-> 22.04 LTS); use Flatpak or the tarball there.
 
 ## Development
 

--- a/io.github.hikaps.couchplay.json
+++ b/io.github.hikaps.couchplay.json
@@ -13,7 +13,8 @@
         "--device=dri",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--system-talk-name=org.freedesktop.login1",
-        "--filesystem=/run/udev:ro"
+        "--filesystem=/run/udev:ro",
+        "--filesystem=home"
     ],
     "modules": [
         {

--- a/io.github.hikaps.couchplay.json
+++ b/io.github.hikaps.couchplay.json
@@ -13,8 +13,7 @@
         "--device=dri",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--system-talk-name=org.freedesktop.login1",
-        "--filesystem=/run/udev:ro",
-        "--filesystem=home"
+        "--filesystem=/run/udev:ro"
     ],
     "modules": [
         {

--- a/scripts/bundle-libs.sh
+++ b/scripts/bundle-libs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 CouchPlay Contributors
+#
+# Bundle the runtime shared libraries of an ELF binary next to it and set an
+# $ORIGIN-relative RPATH so it runs without system copies of those libs.
+#
+# Used for the privileged helper so it starts on minimal distros (e.g. Arch with
+# no system Qt6/Polkit). glibc and the dynamic linker are deliberately NOT bundled
+# — they must stay system-provided, which is why the binary still has a glibc floor
+# (see the build container in the release workflow).
+#
+# Usage: bundle-libs.sh <binary> [librel]
+#   binary : ELF binary to process (in place)
+#   librel : lib dir relative to $ORIGIN/.. (default: lib/couchplay)
+# Requires: patchelf
+set -euo pipefail
+
+bin="${1:?usage: bundle-libs.sh <binary> [librel]}"
+librel="${2:-lib/couchplay}"
+
+command -v patchelf >/dev/null 2>&1 || { echo "patchelf not found" >&2; exit 1; }
+
+bindir="$(cd "$(dirname "$bin")" && pwd)"
+libdir="$bindir/../$librel"
+rm -rf "$libdir"
+mkdir -p "$libdir"
+
+# glibc core + dynamic linker must stay system-provided (bundling them breaks the
+# loader on other systems). Keep libstdc++/libgcc_s (C++ ABI portability).
+exclude='^(libc|ld-linux|libdl|libm|libpthread|librt|libresolv|libutil|libcrypt|libBrokenLocale|libanl)\.so'
+
+# ldd prints resolved deps as "<soname> => <abspath> (0x...)". Copy each one
+# (following symlinks so the file is named by its SONAME) except the glibc family.
+ldd "$bin" 2>/dev/null | awk '/=> \// {print $3}' | sort -u | while IFS= read -r lib; do
+    [[ -n "$lib" ]] || continue
+    base="$(basename "$lib")"
+    if [[ "$base" =~ $exclude ]]; then
+        continue
+    fi
+    cp -L "$lib" "$libdir/"
+done
+
+# RPATH is relative to the binary's own location ($ORIGIN = its directory).
+patchelf --set-rpath "\$ORIGIN/../$librel" "$bin" >/dev/null
+
+count=$(find "$libdir" -maxdepth 1 -type f | wc -l)
+echo "Bundled ${count} library(ies) for $(basename "$bin") -> ${libdir} (RPATH \$ORIGIN/../${librel})"

--- a/scripts/bundle-libs.sh
+++ b/scripts/bundle-libs.sh
@@ -41,8 +41,12 @@ ldd "$bin" 2>/dev/null | awk '/=> \// {print $3}' | sort -u | while IFS= read -r
     cp -L "$lib" "$libdir/"
 done
 
-# RPATH is relative to the binary's own location ($ORIGIN = its directory).
-patchelf --set-rpath "\$ORIGIN/../$librel" "$bin" >/dev/null
+# Use --force-rpath so the path is DT_RPATH, not DT_RUNPATH. DT_RPATH applies to the
+# whole dependency tree; DT_RUNPATH only resolves the binary's *direct* deps, so the
+# bundled transitive libs (e.g. Qt6Core's libpcre2/libdouble-conversion/libzstd) would
+# be unreachable on minimal systems and the helper would still fail to load (#28).
+# Path is relative to the binary's own location ($ORIGIN = its directory).
+patchelf --force-rpath --set-rpath "\$ORIGIN/../$librel" "$bin" >/dev/null
 
 count=$(find "$libdir" -maxdepth 1 -type f | wc -l)
 echo "Bundled ${count} library(ies) for $(basename "$bin") -> ${libdir} (RPATH \$ORIGIN/../${librel})"

--- a/scripts/install-helper.sh
+++ b/scripts/install-helper.sh
@@ -61,20 +61,17 @@ fi
 # Binary name
 HELPER_BINARY="couchplay-helper"
 
-# Resolve the real host home directory.
-# Inside a Flatpak, $HOME is redirected to the sandbox (~/.var/app/<id>) unless
-# host-home filesystem access is granted. Exporting to the sandbox home means the
-# host-side `sudo ... install` command (and the README) cannot find the files, so
-# resolve the real home from /etc/passwd (shared with the host) instead.
+# Export directory: where the helper files are staged for the host-side `sudo ... install`.
+# Inside a Flatpak the sandbox home ($HOME) is NOT persisted to the host, so writing to
+# $HOME/.local/share silently vanishes (export appears to succeed but no files reach the
+# host). Flatpak persists XDG_DATA_HOME to ~/.var/app/<id>/data on the host — the same
+# absolute path inside the sandbox — so stage files there. No extra filesystem permission
+# is required and the result is host-visible immediately.
 if [[ "$IN_FLATPAK" == "true" ]]; then
-    REAL_HOME="$(awk -F: -v uid="$UID" '$3==uid{print $6}' /etc/passwd 2>/dev/null || true)"
-    HOST_HOME="${REAL_HOME:-$HOME}"
+    EXPORT_DIR="${EXPORT_DIR:-${XDG_DATA_HOME:-${HOME}/.local/share}/couchplay}"
 else
-    HOST_HOME="$HOME"
+    EXPORT_DIR="${EXPORT_DIR:-${HOME}/.local/share/couchplay}"
 fi
-
-# Export directory for Flatpak (user's local share, on the real host home)
-EXPORT_DIR="${EXPORT_DIR:-${HOST_HOME}/.local/share/couchplay}"
 
 # Source paths (relative to script location)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/install-helper.sh
+++ b/scripts/install-helper.sh
@@ -40,6 +40,7 @@ fi
 # On traditional distros, these can be changed to /usr paths
 PREFIX="${PREFIX:-/usr/local}"
 LIBEXEC_DIR="${LIBEXEC_DIR:-${PREFIX}/libexec}"
+LIB_DIR="${LIB_DIR:-${PREFIX}/lib/couchplay}"
 DBUS_SYSTEM_DIR="${DBUS_SYSTEM_DIR:-/etc/dbus-1/system.d}"
 DBUS_SERVICE_DIR="${DBUS_SERVICE_DIR:-${PREFIX}/share/dbus-1/system-services}"
 SYSTEMD_DIR="${SYSTEMD_DIR:-/etc/systemd/system}"
@@ -223,6 +224,15 @@ install_helper() {
     print_info "Installing binary to ${LIBEXEC_DIR}/"
     install -Dm755 "${BINARY_PATH}" "${LIBEXEC_DIR}/${HELPER_BINARY}"
 
+    # Install bundled runtime libraries, if the release ships them (the binary's
+    # RPATH is $ORIGIN/../lib/couchplay, so this lets the helper run without
+    # system Qt6/Polkit). Absent for Flatpak/build-dir installs.
+    if [[ -d "${SCRIPT_DIR}/lib/couchplay" ]]; then
+        print_info "Installing bundled runtime libraries to ${LIB_DIR}/"
+        mkdir -p "${LIB_DIR}"
+        install -m644 "${SCRIPT_DIR}/lib/couchplay"/*.so* "${LIB_DIR}/"
+    fi
+
     # Install D-Bus configuration
     print_info "Installing D-Bus configuration..."
     install -Dm644 "${DATA_DIR}/dbus/io.github.hikaps.CouchPlayHelper.conf" \
@@ -302,6 +312,7 @@ uninstall_helper() {
     rm -f "${SYSTEMD_DIR}/couchplay-helper.service"
     rm -f "${POLKIT_DIR}/io.github.hikaps.couchplay.policy"
     rm -f "${PREFIX}/share/pipewire/pipewire-pulse.conf.d/50-couchplay.conf"
+    rm -rf "${LIB_DIR}"
 
     # Reload systemd
     print_info "Reloading systemd..."

--- a/scripts/install-helper.sh
+++ b/scripts/install-helper.sh
@@ -227,7 +227,7 @@ install_helper() {
     # Install bundled runtime libraries, if the release ships them (the binary's
     # RPATH is $ORIGIN/../lib/couchplay, so this lets the helper run without
     # system Qt6/Polkit). Absent for Flatpak/build-dir installs.
-    if [[ -d "${SCRIPT_DIR}/lib/couchplay" ]]; then
+    if [[ -d "${SCRIPT_DIR}/lib/couchplay" ]] && compgen -G "${SCRIPT_DIR}/lib/couchplay/*.so*" >/dev/null; then
         print_info "Installing bundled runtime libraries to ${LIB_DIR}/"
         mkdir -p "${LIB_DIR}"
         install -m644 "${SCRIPT_DIR}/lib/couchplay"/*.so* "${LIB_DIR}/"
@@ -402,7 +402,7 @@ usage() {
     if [[ "$IN_FLATPAK" == "true" ]]; then
         echo "Running inside Flatpak detected."
         echo "To install the helper, first run: $0 export"
-        echo "Then on the host: sudo ~/.local/share/couchplay/install-helper.sh install"
+        echo "Then on the host: sudo ${EXPORT_DIR}/install-helper.sh install"
         echo ""
     fi
     echo "Environment variables:"
@@ -412,7 +412,7 @@ usage() {
     echo "  DBUS_SERVICE_DIR D-Bus service activation dir (default: \$PREFIX/share/dbus-1/system-services)"
     echo "  SYSTEMD_DIR     Systemd unit directory (default: /etc/systemd/system)"
     echo "  POLKIT_DIR      Polkit policy directory (default: /usr/share/polkit-1/actions)"
-    echo "  EXPORT_DIR      Export directory for Flatpak (default: ~/.local/share/couchplay)"
+    echo "  EXPORT_DIR      Where helper files are staged for host install (default: \$XDG_DATA_HOME/couchplay in Flatpak, else ~/.local/share/couchplay)"
 }
 
 # Check for Flatpak context and provide guidance

--- a/scripts/install-helper.sh
+++ b/scripts/install-helper.sh
@@ -61,8 +61,20 @@ fi
 # Binary name
 HELPER_BINARY="couchplay-helper"
 
-# Export directory for Flatpak (user's local share)
-EXPORT_DIR="${EXPORT_DIR:-${HOME}/.local/share/couchplay}"
+# Resolve the real host home directory.
+# Inside a Flatpak, $HOME is redirected to the sandbox (~/.var/app/<id>) unless
+# host-home filesystem access is granted. Exporting to the sandbox home means the
+# host-side `sudo ... install` command (and the README) cannot find the files, so
+# resolve the real home from /etc/passwd (shared with the host) instead.
+if [[ "$IN_FLATPAK" == "true" ]]; then
+    REAL_HOME="$(awk -F: -v uid="$UID" '$3==uid{print $6}' /etc/passwd 2>/dev/null || true)"
+    HOST_HOME="${REAL_HOME:-$HOME}"
+else
+    HOST_HOME="$HOME"
+fi
+
+# Export directory for Flatpak (user's local share, on the real host home)
+EXPORT_DIR="${EXPORT_DIR:-${HOST_HOME}/.local/share/couchplay}"
 
 # Source paths (relative to script location)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,6 +128,28 @@ check_binary() {
         echo "    make"
         exit 1
     fi
+}
+
+reload_dbus() {
+    # Ask the D-Bus daemon to re-read its configuration so policy files dropped
+    # into /etc/dbus-1/system.d/ (e.g. the helper's ownership allow-rule) take
+    # effect. Without this the helper cannot register its service name and the
+    # Type=dbus systemd unit fails to start. Tries the systemd unit reload first,
+    # then falls back to signalling the daemon directly via its pid file.
+    if systemctl reload dbus 2>/dev/null; then
+        return 0
+    fi
+    local pidfile dbus_pid
+    for pidfile in /run/dbus/pid /var/run/dbus/pid; do
+        if [[ -r "$pidfile" ]]; then
+            dbus_pid="$(cat "$pidfile" 2>/dev/null || true)"
+            if [[ -n "$dbus_pid" ]] && kill -HUP "$dbus_pid" 2>/dev/null; then
+                print_warn "systemctl reload dbus unavailable; sent SIGHUP to dbus-daemon (pid ${dbus_pid})."
+                return 0
+            fi
+        fi
+    done
+    return 1
 }
 
 export_helper() {
@@ -222,14 +256,30 @@ install_helper() {
     print_info "Reloading systemd..."
     systemctl daemon-reload
 
-    # Reload D-Bus
+    # Reload D-Bus so the new ownership policy in /etc/dbus-1/system.d/ takes
+    # effect. Without this the helper cannot register its service name and the
+    # Type=dbus unit fails to start. Do not silently mask a reload failure.
     print_info "Reloading D-Bus configuration..."
-    systemctl reload dbus 2>/dev/null || true
+    if ! reload_dbus; then
+        print_warn "Could not reload D-Bus configuration automatically."
+        print_warn "If the service fails to start, run: sudo systemctl reload dbus  (or reboot)"
+    fi
 
     # Enable and restart service (restart ensures new binary is loaded)
     print_info "Enabling and restarting service..."
     systemctl enable couchplay-helper.service
-    systemctl restart couchplay-helper.service
+    if ! systemctl restart couchplay-helper.service; then
+        echo ""
+        print_error "Failed to start couchplay-helper.service"
+        echo ""
+        echo "---- journalctl (last 30 lines) ----"
+        journalctl -u couchplay-helper.service -n 30 --no-pager 2>&1 || true
+        echo "------------------------------------"
+        echo ""
+        echo "For full logs, run:"
+        echo "    journalctl -xeu couchplay-helper.service"
+        exit 1
+    fi
 
     print_info "Installation complete!"
     echo ""
@@ -260,9 +310,9 @@ uninstall_helper() {
     print_info "Reloading systemd..."
     systemctl daemon-reload
 
-    # Reload D-Bus
+    # Reload D-Bus so the removed ownership policy takes effect.
     print_info "Reloading D-Bus configuration..."
-    systemctl reload dbus 2>/dev/null || true
+    reload_dbus || print_warn "Could not reload D-Bus; changes apply after a reboot."
 
     print_info "Uninstallation complete!"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -138,6 +138,44 @@ check_architecture() {
     print_info "Architecture check passed: $arch"
 }
 
+check_binary_deps() {
+    # The release tarball does NOT bundle runtime libraries; the helper and GUI link
+    # against system Qt6, KDE Frameworks 6, Polkit and PipeWire. If a required shared
+    # library is missing the helper fails to start with an opaque exit code (e.g. the
+    # "Main process exited" / ERRNO 2 seen on minimal Arch installs). Detect missing
+    # libs up front so the user gets a clear, actionable message instead.
+    local extract_dir="$1"
+    local bin_dir helper missing
+    bin_dir=$(find "$extract_dir" -type d -name "bin" | head -1)
+    [[ -z "$bin_dir" ]] && return 0
+    helper="${bin_dir}/couchplay-helper"
+    [[ -x "$helper" ]] || return 0
+
+    if ! missing=$(ldd "$helper" 2>/dev/null | grep -i 'not found'); then
+        return 0
+    fi
+    [[ -z "$missing" ]] && return 0
+
+    print_error "The helper binary is missing required shared libraries on this system:"
+    echo ""
+    echo "$missing" | sed -E 's/^[[:space:]]+//; s/[[:space:]]*=>.*//' | sort -u \
+        | while IFS= read -r lib; do [[ -n "$lib" ]] && echo "  $lib"; done
+    echo ""
+    echo "The CouchPlay release does not bundle runtime libraries; it links against"
+    echo "system Qt6, KDE Frameworks 6, Polkit and PipeWire. Install the packages"
+    echo "providing the libraries listed above, then re-run this installer."
+    echo ""
+    echo "On Arch Linux / CachyOS:"
+    echo "  sudo pacman -S qt6-base polkit-qt6 kirigami pipewire"
+    echo ""
+    echo "On Fedora:"
+    echo "  sudo dnf install qt6-qtbase polkit-qt6-1-devel kf6-kirigami pipewire"
+    echo ""
+    echo "On Debian/Ubuntu:"
+    echo "  sudo apt install qt6-base-dev libpolkit-qt6-1-1 kirigami pipewire"
+    exit 1
+}
+
 # =============================================================================
 # GitHub API Functions
 # =============================================================================
@@ -510,6 +548,9 @@ main() {
     if ! extract_tarball "$tarball_file" "$extract_dir"; then
         exit 1
     fi
+
+    # Verify the helper's runtime libraries are present (the tarball doesn't bundle them).
+    check_binary_deps "$extract_dir"
     
     # Install main binary
     echo ""


### PR DESCRIPTION
## Summary

Fixes the two install failures reported in #28 (reporter is on the **stable** release from `main`; these fixes land on `develop` and flow to `main` on the next release).

### 1. `couchplay-helper.service` fails to start (curl/tarball method)

The systemd unit is `Type=dbus`, so systemd reports *"control process exited with error code"* when the binary exits non-zero before taking `BusName`. That phrasing rules out a timeout and `203/EXEC` (missing lib) — it is the helper's own `return 1` in `helper/main.cpp`, almost certainly `registerService()` being denied because the ownership policy in `/etc/dbus-1/system.d/` was never loaded.

Root cause: `install-helper.sh` ran `systemctl reload dbus 2>/dev/null || true`, **masking the reload failure**. Worked on Bazzite (the dev distro); failed on CachyOS.

Fix (`scripts/install-helper.sh`):
- New `reload_dbus()`: tries `systemctl reload dbus`, falls back to `SIGHUP` via `/run/dbus/pid` (or `/var/run/dbus/pid`); **no more `|| true` masking**.
- `install_helper`: warns loudly on reload failure; on `systemctl restart` failure, dumps the last 30 `journalctl` lines + the exact follow-up command — so the next reporter sees the cause instead of a bare "Helper installation failed".
- `uninstall_helper`: uses the same `reload_dbus` helper.

### 2. Flatpak `export` copies nothing to `~/.local/share` (Flatpak method)

CONFIRMED, deterministic. The manifest had no `--filesystem=home`, so inside the sandbox `$HOME` = `~/.var/app/io.github.hikaps.couchplay`. `export` wrote there, but the README's next command (`sudo ~/.local/share/couchplay/install-helper.sh install`) found an empty dir.

Fix:
- `io.github.hikaps.couchplay.json`: added `"--filesystem=home"` to `finish-args` so `$HOME` resolves to the real host home.
- `scripts/install-helper.sh`: `EXPORT_DIR` now resolves the **real host home** from `/etc/passwd` when running inside a Flatpak (robust whether or not `$HOME` is remapped).
- `README.md`: documents where `export` writes, with an **older-build fallback** (`sudo ~/.var/app/io.github.hikaps.couchplay/.local/share/couchplay/install-helper.sh install`) for users on the current stable build.

## Verification
- `bash -n scripts/install-helper.sh` clean; `python3 -m json.tool` on the manifest valid.
- Host-home `awk` resolution returns `/home/notaname` == `$HOME` exactly.
- `reload_dbus` fallback exercised: with `systemctl reload` stubbed to fail and a live pid in the pidfile, it SIGHUPs the pid and returns `0` (signal delivery confirmed).

## Behavior-change note
`--filesystem=home` means the Flatpak now reads/writes the real `~/.local/share/couchplay/profiles/` instead of the sandboxed copy, consistent with the non-Flatpak install. Previously-created Flatpak profiles won't carry over — worth a release note.

## Notes
- No C++/QML changed; unit-test suite is unaffected.
- The exact `return 1` branch for bug 1 is ~90% likely `registerService()` but is not 100% pinned without the reporter's `journalctl`. The fix is correct-and-diagnostic either way: the reload+fallback handles the leading cause, and the journal dump nails any other.

Refs #28
