### PR TITLE
feat: portable AppImage build (bundled Qt6/KF6 runtime)

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,62 @@
+name: AppImage
+
+# Portable single-file build: GUI bundled with Qt6/KF6 runtime libs so it runs on
+# any glibc >= build-baseline desktop without system Qt6/KF6. The privileged
+# helper is carried inside and installed on demand via
+#   ./CouchPlay-x86_64.AppImage install-helper
+#
+# NOTE on portability: the glibc baseline is set by the container below
+# (fedora:40 = glibc 2.39). The resulting AppImage runs on Arch/Fedora/Ubuntu
+# 24.04 LTS/Debian 13 and newer. To support older LTS releases (Debian 12 /
+# Ubuntu 22.04, glibc 2.35/2.36) you must lower the base AND ensure KF6 is
+# available there (it is not in their default repos — would require building KF6
+# from source), so that is left as a follow-up rather than silently producing a
+# broken build.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  appimage:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:40
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install build dependencies
+        run: |
+          dnf install -y cmake gcc-c++ git make curl \
+            qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qt5compat-devel \
+            kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
+            kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
+            kf6-kglobalaccel-devel extra-cmake-modules \
+            pipewire-devel polkit-devel polkit-qt6-1-devel
+
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Build AppImage
+        run: |
+          chmod +x scripts/build-appimage.sh
+          ./scripts/build-appimage.sh
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: appimage
+          path: CouchPlay-x86_64.AppImage
+
+      - name: Upload to Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: CouchPlay-x86_64.AppImage

--- a/README.md
+++ b/README.md
@@ -130,31 +130,6 @@ sudo ./install-helper.sh uninstall
 
 > **Note**: The tarball installation method above is also available if you prefer it or your distribution doesn't support Flatpak.
 
-## AppImage Installation
-
-An AppImage bundles the GUI with its Qt6/KDE Frameworks runtime libraries, so it runs on
-most current x86_64 Linux desktops (Arch, Fedora, Ubuntu 24.04 LTS, Debian 13 and newer)
-without installing Qt6/KF6 system-wide.
-
-1. **Download** `CouchPlay-x86_64.AppImage` from the [Releases page](../../releases).
-2. **Make it executable** and **launch the GUI**:
-   ```bash
-   chmod +x CouchPlay-x86_64.AppImage
-   ./CouchPlay-x86_64.AppImage
-   ```
-3. **Install the helper service** (required for device management — the helper runs from
-   system paths, not the AppImage):
-   ```bash
-   ./CouchPlay-x86_64.AppImage install-helper
-   ```
-   This extracts the privileged helper and runs `install-helper.sh install` with `sudo`.
-   The helper links against system Qt6/Polkit — if any are missing the installer reports
-   them with the packages to install (e.g. on Arch: `sudo pacman -S qt6-base polkit-qt6`).
-
-> **Portability note**: the AppImage's compatibility floor is the glibc it was built against
-> (currently glibc 2.39). It will not run on older LTS releases such as Debian 12 or
-> Ubuntu 22.04 LTS; use the Flatpak or tarball methods there.
-
 ## Development
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ sudo ./install-helper.sh uninstall
 
 > **Note**: The tarball installation method above is also available if you prefer it or your distribution doesn't support Flatpak.
 
+## AppImage Installation
+
+An AppImage bundles the GUI with its Qt6/KDE Frameworks runtime libraries, so it runs on
+most current x86_64 Linux desktops (Arch, Fedora, Ubuntu 24.04 LTS, Debian 13 and newer)
+without installing Qt6/KF6 system-wide.
+
+1. **Download** `CouchPlay-x86_64.AppImage` from the [Releases page](../../releases).
+2. **Make it executable** and **launch the GUI**:
+   ```bash
+   chmod +x CouchPlay-x86_64.AppImage
+   ./CouchPlay-x86_64.AppImage
+   ```
+3. **Install the helper service** (required for device management — the helper runs from
+   system paths, not the AppImage):
+   ```bash
+   ./CouchPlay-x86_64.AppImage install-helper
+   ```
+   This extracts the privileged helper and runs `install-helper.sh install` with `sudo`.
+   The helper links against system Qt6/Polkit — if any are missing the installer reports
+   them with the packages to install (e.g. on Arch: `sudo pacman -S qt6-base polkit-qt6`).
+
+> **Portability note**: the AppImage's compatibility floor is the glibc it was built against
+> (currently glibc 2.39). It will not run on older LTS releases such as Debian 12 or
+> Ubuntu 22.04 LTS; use the Flatpak or tarball methods there.
+
 ## Development
 
 ### Prerequisites

--- a/scripts/AppRun
+++ b/scripts/AppRun
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 CouchPlay Contributors
+#
+# Custom AppRun for the CouchPlay AppImage.
+#
+#   ./CouchPlay-x86_64.AppImage                  -> launch the GUI
+#   ./CouchPlay-x86_64.AppImage install-helper   -> extract the privileged helper
+#                                                  + installer to a temp dir and run
+#                                                  `install-helper.sh install` with sudo
+#
+# The GUI runs against the Qt6/KF6 libraries bundled inside the AppImage. The
+# privileged helper cannot live in the (ephemeral, read-only) AppImage mount, so
+# it is carried inside and installed into system paths on demand — exactly like
+# the tarball install. Once installed, the helper uses the system Qt6/Polkit
+# libraries (see install-helper.sh dependency checks).
+set -e
+
+# The AppImage type-2 runtime exports APPDIR (the squashfs mount point).
+APPDIR="${APPDIR:-$(dirname "$(readlink -f "$0")")}"
+
+# Point Qt/loader at the libraries, plugins and QML modules bundled by linuxdeploy.
+export LD_LIBRARY_PATH="${APPDIR}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export QT_PLUGIN_PATH="${APPDIR}/usr/plugins${QT_PLUGIN_PATH:+:${QT_PLUGIN_PATH}}"
+export QML2_IMPORT_PATH="${APPDIR}/usr/qml${QML2_IMPORT_PATH:+:${QML2_IMPORT_PATH}}"
+
+case "${1:-}" in
+    install-helper)
+        shift
+        TMPDIR="$(mktemp -d)"
+        trap 'rm -rf "$TMPDIR"' EXIT
+        # Lay out a release-tarball structure so install-helper.sh detects it:
+        #   $TMPDIR/bin/couchplay-helper
+        #   $TMPDIR/data/{dbus,polkit,pipewire}
+        #   $TMPDIR/install-helper.sh
+        mkdir -p "$TMPDIR/bin" "$TMPDIR/data"
+        cp "$APPDIR/usr/libexec/couchplay-helper" "$TMPDIR/bin/"
+        cp "$APPDIR/usr/share/couchplay/install-helper.sh" "$TMPDIR/"
+        cp -r "$APPDIR/usr/share/couchplay/data/." "$TMPDIR/data/"
+        echo "Extracted helper installer to $TMPDIR"
+        echo "Running installer as root..."
+        exec sudo "$TMPDIR/install-helper.sh" install
+        ;;
+    *)
+        exec "$APPDIR/usr/bin/couchplay" "$@"
+        ;;
+esac

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 CouchPlay Contributors
+#
+# Build a portable CouchPlay AppImage.
+#
+# The GUI (couchplay) is bundled with its Qt6/KF6 runtime libraries so it runs on
+# any glibc >= build-baseline desktop without system Qt6/KF6. The privileged
+# helper cannot run from the AppImage mount, so it is carried inside and installed
+# on demand via `./CouchPlay-x86_64.AppImage install-helper`.
+#
+# Build baseline = the container this runs in. In CI we use fedora:40 (glibc 2.39)
+# so the AppImage runs on Arch/Fedora/Ubuntu 24.04 LTS/Debian 13 and newer. To
+# widen compatibility, lower the base (e.g. an older distro) — but KF6 must be
+# available there.
+#
+# Usage: ./scripts/build-appimage.sh
+# Env:   BUILD_DIR, APPDIR, ARCH, TOOLS_DIR, OUTPUT (all optional)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+APPDIR="${APPDIR:-AppDir}"
+ARCH="${ARCH:-$(uname -m)}"
+OUTPUT="${OUTPUT:-CouchPlay-${ARCH}.AppImage}"
+TOOLS_DIR="${TOOLS_DIR:-${ROOT}/.appimage-tools}"
+
+# AppImage tools may need to run where FUSE is unavailable (CI containers).
+export APPIMAGE_EXTRACT_AND_RUN=1
+export NO_STRIP=1
+
+echo "==> Building CouchPlay (${ARCH})"
+cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
+cmake --build "$BUILD_DIR" -j"$(nproc)"
+
+echo "==> Preparing AppDir"
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/libexec" "$APPDIR/usr/share/couchplay/data"
+
+# GUI binary is placed/bundled by linuxdeploy below.
+# Helper + installer + privileged data are carried verbatim (no bundling: the
+# helper runs from system paths after `install-helper` and uses system Qt6).
+cp "$BUILD_DIR/bin/couchplay-helper" "$APPDIR/usr/libexec/"
+cp scripts/install-helper.sh "$APPDIR/usr/share/couchplay/"
+cp -r data/dbus data/polkit data/pipewire "$APPDIR/usr/share/couchplay/data/"
+
+echo "==> Fetching linuxdeploy / Qt plugin / appimagetool"
+mkdir -p "$TOOLS_DIR"
+fetch() { # <url> <dest>
+    if [[ ! -x "$2" ]]; then
+        curl -fsSL "$1" -o "$2"
+        chmod +x "$2"
+    fi
+}
+LINUXDEPLOY="$TOOLS_DIR/linuxdeploy-${ARCH}.AppImage"
+QT_PLUGIN="$TOOLS_DIR/linuxdeploy-plugin-qt-${ARCH}.AppImage"
+APPIMAGETOOL="$TOOLS_DIR/appimagetool-${ARCH}.AppImage"
+fetch "https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-${ARCH}.AppImage" "$LINUXDEPLOY"
+fetch "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/latest/download/linuxdeploy-plugin-qt-${ARCH}.AppImage" "$QT_PLUGIN"
+fetch "https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-${ARCH}.AppImage" "$APPIMAGETOOL"
+
+echo "==> Bundling GUI + Qt6/KF6 runtime (linuxdeploy + Qt plugin)"
+# Only `couchplay` is bundled (the GUI). --custom-apprun installs our wrapper that
+# supports the `install-helper` subcommand and sets Qt library/plugin paths.
+"$LINUXDEPLOY" --appdir "$APPDIR" \
+    --executable "$BUILD_DIR/bin/couchplay" \
+    --desktop-file data/io.github.hikaps.couchplay.desktop \
+    --icon-file data/icons/io.github.hikaps.couchplay.png \
+    --custom-apprun "$ROOT/scripts/AppRun" \
+    --plugin qt
+
+echo "==> Packaging AppImage"
+rm -f "$OUTPUT"
+ARCH="$ARCH" "$APPIMAGETOOL" "$APPDIR" "$OUTPUT"
+
+echo "==> Built $OUTPUT"


### PR DESCRIPTION
## Summary

Adds a portable **AppImage** distribution: the GUI bundled with its Qt6/KF6 runtime libraries, so it runs on current x86_64 desktops without installing Qt6/KF6 system-wide. Came out of the #28 install discussion as a "runs anywhere" option alongside Flatpak.

### How it's structured
- **GUI** (`couchplay`): bundled via `linuxdeploy` + `linuxdeploy-plugin-qt` (Qt plugins, QML imports, libs). Runs from the AppImage against the bundled runtime.
- **Privileged helper**: cannot live in the read-only/ephemeral AppImage mount (it's a root `Type=dbus` daemon). So it's **carried inside** and installed on demand via a custom `AppRun` subcommand:
  ```bash
  ./CouchPlay-x86_64.AppImage install-helper
  ```
  This extracts the helper + installer to a temp dir and runs the existing `install-helper.sh install` with `sudo` — landing the helper in system paths exactly like the tarball. The helper then uses **system** Qt6/Polkit (the AppImage's bundled libs are for the GUI only); missing ones are reported by the dep-detection in `install-helper.sh`/`install.sh`.

### Files
- `scripts/AppRun` — custom AppRun: launches GUI by default; `install-helper` subcommand extracts + installs the privileged helper.
- `scripts/build-appimage.sh` — builds, fetches linuxdeploy/Qt-plugin/appimagetool, bundles the GUI, packages the AppImage.
- `.github/workflows/appimage.yml` — `fedora:40` container (glibc **2.39** baseline), triggers on `v*` tags + `workflow_dispatch`, uploads the AppImage to the release.
- `README.md` — AppImage install section.

### Portability
glibc forward-compat means the AppImage runs on any distro with glibc ≥ the build baseline. `fedora:40` (glibc 2.39) covers Arch/CachyOS, Fedora, Ubuntu 24.04 LTS, Debian 13, openSUSE Tumbleweed. It will **not** run on Debian 12 / Ubuntu 22.04 LTS (older glibc); the workflow file documents how to lower the baseline (requires KF6 available on the older base — not in their default repos, so it's a follow-up). Flatpak remains the zero-glibc-constraint method.

### ⚠️ Verification status — needs a CI run
I could **not** build this locally (full KDE/Qt6 toolchain in a Fedora container). Verified so far:
- `bash -n` clean on `AppRun` and `build-appimage.sh`; YAML valid.
- AppRun env wiring (`LD_LIBRARY_PATH`/`QT_PLUGIN_PATH`/`QML2_IMPORT_PATH`) and the `install-helper` extraction layout match `install-helper.sh`'s release-tarball structure detection.

To validate, trigger the workflow on this branch:
```bash
gh workflow run appimage.yml --repo hikaps/couchplay --ref feature/appimage
```
Things to confirm on that run: (a) `fedora:40` resolves the `kf6-*`/`qt6-*` dnf deps, (b) `linuxdeploy` + Qt plugin bundle the Wayland platform plugin correctly, (c) the resulting AppImage boots the GUI on a clean system, (d) `install-helper` extracts and installs the helper.

### Out of scope (follow-ups)
- Bundle libs into the **helper's** system install (patchelf RPATH + `install-helper.sh` lib-dir install) so the helper also runs without system Qt6 — that's the change that would make #28's helper fully portable.
- Older-LTS support (lower glibc baseline + KF6 from source).

Refs #28
