### PR TITLE
test(e2e): fix session-test pollution (stop session between tests)

### DIFF
--- a/appiumtests/conftest.py
+++ b/appiumtests/conftest.py
@@ -169,6 +169,31 @@ def go_home(driver):
     wait.until(EC.presence_of_element_located((AppiumBy.NAME, "Welcome to CouchPlay")))
 
 
+def stop_session_if_running(driver, timeout=2):
+    """Ensure no session is left running between session tests.
+
+    sessionRunner is a global manager that persists across pages, so a test
+    that starts a session but never stops it leaves the Start/Stop toolbar
+    action reading "Stop Session" -- and the next test waiting for "Start
+    Session" times out (observed: test_streaming_session_calls_helper fails
+    after test_two_instances_launch). Navigates to SessionSetup (where the
+    action lives) and stops if running; a no-op when nothing is. Scoped to
+    session tests via an autouse fixture in TestSessionLifecycle so the other
+    ~43 tests pay no per-test navigation overhead.
+    """
+    from selenium.common.exceptions import TimeoutException
+
+    try:
+        go_home(driver)
+        click_by_object_name(driver, "cardNewSession", timeout)
+        wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "spinPlayerCount", timeout)
+        stop_btn = wait_for_element_clickable(driver, AppiumBy.NAME, "Stop Session", timeout)
+        stop_btn.click()
+        wait_for_element(driver, AppiumBy.NAME, "Start Session", timeout=5)
+    except TimeoutException:
+        pass
+
+
 def wait_for_element(driver, by, value, timeout=DEFAULT_TIMEOUT):
     return WebDriverWait(driver, timeout).until(
         EC.presence_of_element_located((by, value))

--- a/appiumtests/test_session.py
+++ b/appiumtests/test_session.py
@@ -4,6 +4,7 @@
 import pytest
 from appium.webdriver.common.appiumby import AppiumBy
 from helpers.base_test import BaseTest
+from conftest import stop_session_if_running
 
 import json
 import os
@@ -19,6 +20,16 @@ LONG_TIMEOUT = int(os.environ.get("COUCHPLAY_E2E_LONG_TIMEOUT") or "20")
 
 
 class TestSessionLifecycle(BaseTest):
+    @pytest.fixture(autouse=True)
+    def _stop_session_after(self, driver):
+        # sessionRunner is global and persists across tests. Without stopping
+        # a session here, a test that starts one (e.g. test_two_instances_launch)
+        # leaves the toolbar action on "Stop Session", so the next test's wait
+        # for "Start Session" times out. Scoped to this class so the other ~43
+        # tests pay no overhead.
+        yield
+        stop_session_if_running(driver)
+
     def test_session_setup_with_helper(self, driver, mock_helper, test_users):
         self.navigate_to_session_setup(driver)
         title = self.wait_for_element(


### PR DESCRIPTION
## Problem
`test_streaming_session_calls_helper` **failed in the full e2e suite** (TimeoutException waiting for `"Start Session"`) but **passed in isolation**. Root cause is test pollution, not the viewport.

`sessionRunner` is a global manager that persists across tests. `test_two_instances_launch` clicks Start and never Stop, leaving `running=true`, so the Start/Stop toolbar action reads `"Stop Session"` — the next test's `click_by_name("Start Session")` times out.

## Fix
- **`appiumtests/conftest.py`** — add `stop_session_if_running(driver)`: navigate to SessionSetup → click `"Stop Session"` if present → wait for `"Start Session"`.
- **`appiumtests/test_session.py`** — `TestSessionLifecycle` gets a class-scoped `autouse` fixture (`_stop_session_after`) calling it after each test.

Scoped to the session tests (where every polluter and victim lives) so the other ~43 tests pay no per-test navigation overhead. Applying it globally via `clean_state` worked but added ~13 min and pushed the suite past the 30-min ceiling.

## Verification
Full e2e suite (rootless container): **52 tests, 0 failures, 0 errors, 5 skipped** (~19 min) — previously **1 failed**. Both `test_two_instances_launch` and `test_streaming_session_calls_helper` now pass.

The 3 viewport-related skips (inline streaming controls off-screen in the small headless viewport) remain — separate, smaller issue (scroll-into-view or a larger nested-kwin output).