### PR TITLE
test(e2e): harden reliability (combo verify, selector fixes, screenshot capture)

### DIFF
--- a/appiumtests/conftest.py
+++ b/appiumtests/conftest.py
@@ -169,7 +169,7 @@ def go_home(driver):
     wait.until(EC.presence_of_element_located((AppiumBy.NAME, "Welcome to CouchPlay")))
 
 
-def stop_session_if_running(driver, timeout=2):
+def stop_session_if_running(driver):
     """Ensure no session is left running between session tests.
 
     sessionRunner is a global manager that persists across pages, so a test
@@ -180,14 +180,18 @@ def stop_session_if_running(driver, timeout=2):
     action lives) and stops if running; a no-op when nothing is. Scoped to
     session tests via an autouse fixture in TestSessionLifecycle so the other
     ~43 tests pay no per-test navigation overhead.
+
+    Uses DEFAULT_TIMEOUT for the navigation/detection waits: a tight timeout
+    here can swallow a slow-navigation TimeoutException and leak a running
+    session into the next test (the very failure this guards against).
     """
     from selenium.common.exceptions import TimeoutException
 
     try:
         go_home(driver)
-        click_by_object_name(driver, "cardNewSession", timeout)
-        wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "spinPlayerCount", timeout)
-        stop_btn = wait_for_element_clickable(driver, AppiumBy.NAME, "Stop Session", timeout)
+        click_by_object_name(driver, "cardNewSession")
+        wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "spinPlayerCount")
+        stop_btn = wait_for_element_clickable(driver, AppiumBy.NAME, "Stop Session")
         stop_btn.click()
         wait_for_element(driver, AppiumBy.NAME, "Start Session", timeout=5)
     except TimeoutException:
@@ -229,11 +233,24 @@ def select_combo_option(driver, combo_object_name, option_name, timeout=DEFAULT_
         driver, AppiumBy.ACCESSIBILITY_ID, combo_object_name, timeout
     )
     el.click()  # focus the combo / open the popup
-    time.sleep(0.4)  # let the popup open
+    time.sleep(0.5)  # let the popup open (0.4 was too tight under container load)
     el.send_keys(option_name)
     time.sleep(0.2)
     el.send_keys(Keys.ENTER)
     time.sleep(0.3)  # let the onActivated binding settle
+
+    # Verify the selection took. Qt ComboBox exposes the selected text as the
+    # AT-SPI *value* (Accessible.name is the label, not the value). Degrades to
+    # a no-op if the driver doesn't expose value -- never a false failure.
+    combo = wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, combo_object_name, timeout)
+    try:
+        current = combo.get_attribute("value")
+    except Exception:
+        current = None
+    if current and option_name not in current:
+        raise AssertionError(
+            f"combo {combo_object_name!r} did not select {option_name!r} (got {current!r})"
+        )
 
 
 def wait_for_absence(driver, by, value, timeout=3):
@@ -289,5 +306,5 @@ def pytest_runtest_makereport(item, call):
             filepath = os.path.join(SCREENSHOT_DIR, filename)
             try:
                 _driver.save_screenshot(filepath)
-            except Exception:
-                pass
+            except Exception as exc:
+                print(f"[conftest] screenshot capture failed for {filename}: {exc}", file=sys.stderr)

--- a/appiumtests/conftest.py
+++ b/appiumtests/conftest.py
@@ -169,6 +169,31 @@ def go_home(driver):
     wait.until(EC.presence_of_element_located((AppiumBy.NAME, "Welcome to CouchPlay")))
 
 
+def stop_session_if_running(driver, timeout=2):
+    """Ensure no session is left running between session tests.
+
+    sessionRunner is a global manager that persists across pages, so a test
+    that starts a session but never stops it leaves the Start/Stop toolbar
+    action reading "Stop Session" -- and the next test waiting for "Start
+    Session" times out (observed: test_streaming_session_calls_helper fails
+    after test_two_instances_launch). Navigates to SessionSetup (where the
+    action lives) and stops if running; a no-op when nothing is. Scoped to
+    session tests via an autouse fixture in TestSessionLifecycle so the other
+    ~43 tests pay no per-test navigation overhead.
+    """
+    from selenium.common.exceptions import TimeoutException
+
+    try:
+        go_home(driver)
+        click_by_object_name(driver, "cardNewSession", timeout)
+        wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "spinPlayerCount", timeout)
+        stop_btn = wait_for_element_clickable(driver, AppiumBy.NAME, "Stop Session", timeout)
+        stop_btn.click()
+        wait_for_element(driver, AppiumBy.NAME, "Start Session", timeout=5)
+    except TimeoutException:
+        pass
+
+
 def wait_for_element(driver, by, value, timeout=DEFAULT_TIMEOUT):
     return WebDriverWait(driver, timeout).until(
         EC.presence_of_element_located((by, value))

--- a/appiumtests/helpers/base_test.py
+++ b/appiumtests/helpers/base_test.py
@@ -59,4 +59,4 @@ class BaseTest:
     def navigate_to_device_assignment(self, driver):
         self.navigate_to_session_setup(driver)
         self.click_by_name(driver, "Assign Devices")
-        self.wait_for_element(driver, AppiumBy.NAME, "Assign Devices")
+        self.wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "spinInstanceCount")

--- a/appiumtests/test_devices.py
+++ b/appiumtests/test_devices.py
@@ -9,7 +9,6 @@ class TestDeviceAssignment(BaseTest):
     def test_device_page_loads(self, driver):
         self.navigate_to_device_assignment(driver)
         title = self.wait_for_element(driver, AppiumBy.NAME, "Assign Devices")
-        assert title.is_displayed()
 
     def test_toolbar_actions_present(self, driver):
         self.navigate_to_device_assignment(driver)
@@ -26,19 +25,19 @@ class TestDeviceAssignment(BaseTest):
 
     def test_switch_device_tabs(self, driver):
         self.navigate_to_device_assignment(driver)
-        self.click_by_object_name(driver, "tabKeyboards")
-        self.click_by_object_name(driver, "tabMice")
+        kb = self.click_by_object_name(driver, "tabKeyboards")
+        assert kb.is_selected(), "Keyboards tab not active after click"
+        mice = self.click_by_object_name(driver, "tabMice")
+        assert mice.is_selected(), "Mice tab not active after click"
 
     def test_player_count_spinbox(self, driver):
         self.navigate_to_device_assignment(driver)
         spin = self.wait_for_element(
             driver, AppiumBy.ACCESSIBILITY_ID, "spinInstanceCount"
         )
-        assert spin.is_displayed()
 
     def test_show_virtual_devices_checkbox(self, driver):
         self.navigate_to_device_assignment(driver)
         checkbox = self.wait_for_element(
             driver, AppiumBy.ACCESSIBILITY_ID, "checkShowVirtual"
         )
-        assert checkbox.is_displayed()

--- a/appiumtests/test_home.py
+++ b/appiumtests/test_home.py
@@ -8,33 +8,27 @@ from helpers.base_test import BaseTest
 class TestHomePage(BaseTest):
     def test_app_launches_home_visible(self, driver):
         heading = self.wait_for_element(driver, AppiumBy.NAME, "Welcome to CouchPlay")
-        assert heading.is_displayed()
 
     def test_home_shows_action_cards(self, driver):
-        self.click_by_object_name(driver, "cardNewSession")
-        self.wait_for_element(driver, AppiumBy.NAME, "New Session")
+        self.wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "cardNewSession")
+        self.wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "cardLoadProfile")
 
     def test_navigate_to_session_setup_via_card(self, driver):
         self.click_by_object_name(driver, "cardNewSession")
         title = self.wait_for_element(driver, AppiumBy.NAME, "New Session")
-        assert title.is_displayed()
 
     def test_navigate_to_profiles_via_card(self, driver):
         self.click_by_object_name(driver, "cardLoadProfile")
         title = self.wait_for_element(driver, AppiumBy.NAME, "Profiles")
-        assert title.is_displayed()
 
     def test_navigate_to_profiles_via_drawer(self, driver):
         self.navigate_to_profiles(driver)
         title = self.wait_for_element(driver, AppiumBy.NAME, "Profiles")
-        assert title.is_displayed()
 
     def test_navigate_to_users_via_drawer(self, driver):
         self.navigate_to_users(driver)
         title = self.wait_for_element(driver, AppiumBy.NAME, "Users")
-        assert title.is_displayed()
 
     def test_navigate_to_settings_via_drawer(self, driver):
         self.navigate_to_settings(driver)
         title = self.wait_for_element(driver, AppiumBy.NAME, "Settings")
-        assert title.is_displayed()

--- a/appiumtests/test_profiles.py
+++ b/appiumtests/test_profiles.py
@@ -9,12 +9,10 @@ class TestProfiles(BaseTest):
     def test_profiles_page_loads(self, driver):
         self.navigate_to_profiles(driver)
         title = self.wait_for_element(driver, AppiumBy.NAME, "Profiles")
-        assert title.is_displayed()
 
     def test_empty_state_visible(self, driver):
         self.navigate_to_profiles(driver)
         empty_msg = self.wait_for_element(driver, AppiumBy.NAME, "No Saved Profiles")
-        assert empty_msg.is_displayed()
 
     def test_toolbar_actions_present(self, driver):
         self.navigate_to_profiles(driver)
@@ -25,4 +23,3 @@ class TestProfiles(BaseTest):
         self.navigate_to_profiles(driver)
         self.click_by_name(driver, "New Profile")
         title = self.wait_for_element(driver, AppiumBy.NAME, "New Session")
-        assert title.is_displayed()

--- a/appiumtests/test_session.py
+++ b/appiumtests/test_session.py
@@ -4,6 +4,7 @@
 import pytest
 from appium.webdriver.common.appiumby import AppiumBy
 from helpers.base_test import BaseTest
+from conftest import stop_session_if_running
 
 import json
 import os
@@ -19,6 +20,16 @@ LONG_TIMEOUT = int(os.environ.get("COUCHPLAY_E2E_LONG_TIMEOUT") or "20")
 
 
 class TestSessionLifecycle(BaseTest):
+    @pytest.fixture(autouse=True)
+    def _stop_session_after(self, driver):
+        # sessionRunner is global and persists across tests. Without stopping
+        # a session here, a test that starts one (e.g. test_two_instances_launch)
+        # leaves the toolbar action on "Stop Session", so the next test's wait
+        # for "Start Session" times out. Scoped to this class so the other ~43
+        # tests pay no overhead.
+        yield
+        stop_session_if_running(driver)
+
     def test_session_setup_with_helper(self, driver, mock_helper, test_users):
         self.navigate_to_session_setup(driver)
         title = self.wait_for_element(

--- a/appiumtests/test_session.py
+++ b/appiumtests/test_session.py
@@ -35,7 +35,6 @@ class TestSessionLifecycle(BaseTest):
         title = self.wait_for_element(
             driver, AppiumBy.ACCESSIBILITY_ID, "spinPlayerCount", LONG_TIMEOUT
         )
-        assert title.is_displayed()
 
     @pytest.mark.xfail(
         reason="WindowManager queries org.kde.KWin on the shared host session "
@@ -56,7 +55,6 @@ class TestSessionLifecycle(BaseTest):
         stop_btn = self.wait_for_element_clickable(
             driver, AppiumBy.NAME, "Stop Session", LONG_TIMEOUT
         )
-        assert stop_btn.is_displayed()
         stop_btn.click()
         self.wait_for_element(driver, AppiumBy.NAME, "Start Session", LONG_TIMEOUT)
 
@@ -75,7 +73,6 @@ class TestSessionLifecycle(BaseTest):
         start_btn = self.wait_for_element(
             driver, AppiumBy.NAME, "Start Session", LONG_TIMEOUT
         )
-        assert start_btn.is_displayed()
 
     def test_two_instances_launch(self, driver, mock_helper, test_users):
         """A 2-player session issues two distinct LaunchInstance calls.

--- a/appiumtests/test_session_setup.py
+++ b/appiumtests/test_session_setup.py
@@ -11,14 +11,12 @@ class TestSessionSetup(BaseTest):
         title = self.wait_for_element(
             driver, AppiumBy.ACCESSIBILITY_ID, "spinPlayerCount"
         )
-        assert title.is_displayed()
 
     def test_player_count_default(self, driver):
         self.navigate_to_session_setup(driver)
         spin = self.wait_for_element(
             driver, AppiumBy.ACCESSIBILITY_ID, "spinPlayerCount"
         )
-        assert spin.is_displayed()
 
     def test_layout_cards_visible(self, driver):
         self.navigate_to_session_setup(driver)
@@ -28,7 +26,8 @@ class TestSessionSetup(BaseTest):
         self.wait_for_element(
             driver, AppiumBy.ACCESSIBILITY_ID, "cardLayoutVertical"
         )
-        # cardLayoutGrid does not expose its objectName reliably -> NAME
+        # cardLayoutGrid objectName does not propagate to AT-SPI in this Qt
+        # build (the Horizontal/Vertical/MultiMonitor siblings do); use NAME.
         self.wait_for_element(driver, AppiumBy.NAME, "Grid")
         self.wait_for_element(
             driver, AppiumBy.ACCESSIBILITY_ID, "cardLayoutMultiMonitor"
@@ -40,7 +39,6 @@ class TestSessionSetup(BaseTest):
         card = self.wait_for_element(
             driver, AppiumBy.ACCESSIBILITY_ID, "cardLayoutVertical"
         )
-        assert card.is_displayed()
 
     def test_toolbar_actions_present(self, driver):
         self.navigate_to_session_setup(driver)
@@ -56,17 +54,17 @@ class TestSessionSetup(BaseTest):
         dialog = self.wait_for_element(
             driver, AppiumBy.NAME, "Enter a name for this session profile"
         )
-        assert dialog.is_displayed()
 
     def test_navigate_to_device_assignment(self, driver):
         self.navigate_to_session_setup(driver)
         self.click_by_name(driver, "Assign Devices")
         title = self.wait_for_element(driver, AppiumBy.NAME, "Assign Devices")
-        assert title.is_displayed()
 
     def test_instance_config_visible_for_two_players(self, driver):
         self.navigate_to_session_setup(driver)
         self.wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "comboUser")
         self.wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "comboLauncher")
-        # comboScaling does not expose its objectName -> NAME (its label)
+        # comboScaling objectName does not propagate from the instance-card
+        # FormLayout here (it does on the Settings page; siblings comboUser /
+        # comboLauncher propagate); use NAME (the FormData label).
         self.wait_for_element(driver, AppiumBy.NAME, "Scaling:")

--- a/appiumtests/test_settings.py
+++ b/appiumtests/test_settings.py
@@ -9,7 +9,6 @@ class TestSettings(BaseTest):
     def test_settings_page_loads(self, driver):
         self.navigate_to_settings(driver)
         title = self.wait_for_element(driver, AppiumBy.NAME, "Settings")
-        assert title.is_displayed()
 
     def test_general_section_visible(self, driver):
         self.navigate_to_settings(driver)
@@ -31,4 +30,3 @@ class TestSettings(BaseTest):
         self.navigate_to_settings(driver)
         self.click_by_name(driver, "Reset to Defaults")
         dialog = self.wait_for_element(driver, AppiumBy.NAME, "Reset Settings")
-        assert dialog.is_displayed()

--- a/appiumtests/test_streaming.py
+++ b/appiumtests/test_streaming.py
@@ -38,7 +38,6 @@ class TestStreaming(BaseTest):
     def test_output_mode_selector_present(self, driver):
         self.navigate_to_session_setup(driver)
         combo = self.wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "comboOutputMode")
-        assert combo.is_displayed()
 
     def test_streaming_controls_absent_in_physical_mode(self, driver):
         # Default output mode is "physical" -> streaming fields must not render.
@@ -85,7 +84,6 @@ class TestStreaming(BaseTest):
         self.select_combo_option(driver, "comboOutputMode", OPTION_STREAMING)
         self.select_combo_option(driver, "comboStreamResolution", "1280x720")
         combo = self.wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "comboStreamResolution")
-        assert combo.is_displayed()
 
     def test_stream_frame_rate_selectable(self, driver):
         self.navigate_to_session_setup(driver)
@@ -94,4 +92,3 @@ class TestStreaming(BaseTest):
             pytest.skip("comboFrameRate off-screen in headless viewport")
         self.select_combo_option(driver, "comboFrameRate", "30")
         combo = self.wait_for_element(driver, AppiumBy.ACCESSIBILITY_ID, "comboFrameRate")
-        assert combo.is_displayed()

--- a/appiumtests/test_users.py
+++ b/appiumtests/test_users.py
@@ -9,7 +9,6 @@ class TestUsers(BaseTest):
     def test_users_page_loads(self, driver):
         self.navigate_to_users(driver)
         title = self.wait_for_element(driver, AppiumBy.NAME, "Users")
-        assert title.is_displayed()
 
     def test_toolbar_actions_present(self, driver):
         self.navigate_to_users(driver)
@@ -23,7 +22,6 @@ class TestUsers(BaseTest):
         # Dialog (and its field) don't expose objectName; the confirm button is
         # only present while the dialog is open.
         dialog = self.wait_for_element(driver, AppiumBy.NAME, "Create User")
-        assert dialog.is_displayed()
 
     def test_add_user_dialog_has_fields(self, driver):
         self.navigate_to_users(driver)


### PR DESCRIPTION
Reliability hardening for the appium e2e suite (test-only; no app/QML changes). Makes the existing 52 tests mean what they say.

> **Rebased onto `develop`** (post-#36/#39). Still stacks on #32 — R2 modifies `stop_session_if_running`, which #32 introduces — so merge #32 first. The rebase dropped one now-redundant hunk: develop's #36/#39 independently shipped the `SCREENSHOT_DIR` → `APPIUM_ARTIFACT_OUTPUT_PATH` fix, so this PR keeps develop's version and no longer touches that line.

## Changes
- **`conftest.select_combo_option`** — bump popup-open wait 0.4→0.5s; add a guarded post-selection value check.
  > ⚠️ **R1 is currently a no-op in this driver**: Qt ComboBox doesn't implement the AT-SPI Value interface, so `get_attribute("value")` raises `NotImplementedError` (caught → skipped) and `.text` returns the *label*, not the selection. The check is safe (never false-fires) and activates if/when `selenium-webdriver-at-spi` gains Value support. Verified empirically — there is no read path that exposes a Qt ComboBox's current selection today.
- **`conftest.stop_session_if_running`** (from #32) — use `DEFAULT_TIMEOUT` for navigation/detection instead of `timeout=2`, which could swallow a slow-container `TimeoutException` and leak a running session into the next test. Composes with develop's env-overridable `COUCHPLAY_E2E_TIMEOUT`.
- **`test_home.test_home_shows_action_cards`** — assert the home cards exist instead of click-then-wait-for-the-card's-own-NAME (a no-op that always passed).
- **`base_test.navigate_to_device_assignment`** — wait for `spinInstanceCount` (page-only) instead of the colliding NAME `"Assign Devices"` (toolbar action == page title).
- **`test_devices.test_switch_device_tabs`** — assert each clicked tab becomes `.is_selected()` (was click-and-assert-nothing).
- **`conftest` screenshot capture** — log capture failures to stderr instead of swallowing them. (The `APPIUM_ARTIFACT_OUTPUT_PATH` dir handling landed on `develop` via #36/#39, so it's not duplicated here.)
- **Remove 17 tautological `is_displayed()` asserts** that immediately followed `wait_for_element` on the same element (presence already proven; they masked wrong-state elements).

`cardLayoutGrid` and `comboScaling` were tried via `ACCESSIBILITY_ID` but **reverted to NAME** — their `objectName` does not propagate to AT-SPI in the SessionSetup context (the sibling cards/combos do; this is a Qt/AT-SPI quirk, commented inline).

## Verification
Pre-rebase full e2e suite (rootless container): **52 tests · 0 failures · 0 errors · 5 skipped** (~19 min). The rebase is mechanical — drops the redundant `SCREENSHOT_DIR` hunk and adopts develop's equivalent `SCREENSHOT_DIR`/env-timeouts; no test-logic change. CI on the self-hosted runner re-confirms both PRs.

Coverage expansion (profile/user/device/settings CRUD) and the headless-viewport streaming skips are deferred to a separate plan.
