### PR TITLE
fix(install): forward --beta through sudo re-exec + pick branch by flag

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,10 +21,19 @@
 # Re-run with sudo if not root (allows piped input to work with visible output)
 if [[ $EUID -ne 0 ]]; then
     echo "Requesting sudo access to install CouchPlay..."
+    # --beta means a develop build, so re-fetch the installer from develop; otherwise main.
+    # We re-download because piping leaves no script on disk. Forward "$@" so flags
+    # (e.g. --beta) survive the sudo escalation — previously they were silently dropped,
+    # which made the documented --beta one-liner always install stable instead of beta.
+    if [[ " $* " == *" --beta "* ]]; then
+        INSTALLER_BRANCH="develop"
+    else
+        INSTALLER_BRANCH="main"
+    fi
     TMP_SCRIPT=$(mktemp)
-    curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh > "$TMP_SCRIPT"
+    curl -fsSL "https://raw.githubusercontent.com/hikaps/couchplay/${INSTALLER_BRANCH}/scripts/install.sh" > "$TMP_SCRIPT"
     chmod +x "$TMP_SCRIPT"
-    exec sudo "$TMP_SCRIPT"
+    exec sudo "$TMP_SCRIPT" "$@"
 fi
 
 set -e


### PR DESCRIPTION
## Problem

`curl … | bash -s -- --beta` always installed **stable** instead of the beta build, no matter which branch URL was curled. Reported in #28 (CachyOS user kept getting v0.3.4 + a `status=226/NAMESPACE` crash).

## Root cause

The non-root sudo re-exec block at the top of `scripts/install.sh`:

```bash
curl …/main/scripts/install.sh > "$TMP_SCRIPT"
exec sudo "$TMP_SCRIPT"
```

Two bugs:
1. **Hardcoded `main`** — the script the user curled (e.g. `develop`) was discarded after line 28 and re-downloaded from `main`.
2. **Args dropped** — `exec sudo "$TMP_SCRIPT"` passes no `"$@"`, so `--beta` vanished on escalation.

Combined: even on `develop`, `--beta` could never reach `get_beta_release()`; it fell through to `get_latest_release()` → stable v0.3.4. The README's beta URL was only a symptom of this.

## Fix

`scripts/install.sh` — the re-exec now:
- selects the installer branch by flag (`--beta` → `develop`, else `main`), matching `--beta`'s "develop build" semantics;
- forwards `"$@"` through `exec sudo "$TMP_SCRIPT" "$@"` so the flag survives escalation.

```bash
if [[ " $* " == *" --beta "* ]]; then
    INSTALLER_BRANCH="develop"
else
    INSTALLER_BRANCH="main"
fi
…
exec sudo "$TMP_SCRIPT" "$@"
```

## Verification

- `bash -n scripts/install.sh` — clean.
- Branch-selection logic tested for `--beta`, `foo --beta bar`, empty, `--stable`, `--verbose --beta` — all correct.
- No `INSTALLER_BRANCH` collisions; `main()` beta path (`get_beta_release`, `--beta) BETA=true`, `if $BETA`) intact.
- Beta release tarball independently confirmed to contain the `ReadWritePaths=-/var/home` fix.

End-to-end confirmation (bypasses the re-exec by running as root):
```bash
curl -fsSL …/develop/scripts/install.sh -o /tmp/cp-install.sh
sudo bash /tmp/cp-install.sh --beta   # → [WARN] Installing BETA build from develop + releases/download/beta/…
```

## Note

For the documented `curl …/main/… | bash -s -- --beta` one-liner to work, this fix must also reach `main` (the first invocation runs whichever branch is curled). Once merged to `main`, the existing README needs no change — the `main` URL serves both stable and `--beta`.

Refs #28.