### PR TITLE
feat(logging): beta channel auto-enables verbose + rotating-file logging

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./scripts/install-build-deps.sh tar patchelf squashfs-tools
 
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DCOUCHPLAY_BETA=ON
 
       - name: Build
         run: cmake --build build --parallel 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DCOUCHPLAY_BETA=OFF
 
       - name: Build
         run: cmake --build build --parallel 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ find_package(PolkitQt6-1 REQUIRED)
 # Find QML modules at runtime
 ecm_find_qmlmodule(org.kde.kirigami REQUIRED)
 
+# Build for the beta release channel: enables verbose + rotating-file logging.
+# Declared before add_subdirectory(src) because that is where it is consumed.
+# Prod (default) builds stay quiet (warnings only). QT_LOGGING_RULES still overrides.
+option(COUCHPLAY_BETA "Build a beta release with verbose/file logging" OFF)
+
 # Add subdirectories
 add_subdirectory(src)
 add_subdirectory(helper)
@@ -65,9 +70,6 @@ option(BUILD_TESTING "Build the testing tree." ON)
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
-# Build for the beta release channel: enables verbose + rotating-file logging.
-# Prod (default) builds stay quiet (warnings only). QT_LOGGING_RULES still overrides.
-option(COUCHPLAY_BETA "Build a beta release with verbose/file logging" OFF)
 
 # Install desktop file
 install(PROGRAMS data/io.github.hikaps.couchplay.desktop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ option(BUILD_TESTING "Build the testing tree." ON)
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
+# Build for the beta release channel: enables verbose + rotating-file logging.
+# Prod (default) builds stay quiet (warnings only). QT_LOGGING_RULES still overrides.
+option(COUCHPLAY_BETA "Build a beta release with verbose/file logging" OFF)
 
 # Install desktop file
 install(PROGRAMS data/io.github.hikaps.couchplay.desktop

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,10 @@ set_target_properties(couchplay_core PROPERTIES
 # Create the executable
 add_executable(couchplay)
 
+if(COUCHPLAY_BETA)
+    target_compile_definitions(couchplay PRIVATE COUCHPLAY_BETA)
+endif()
+
 # Create QML module
 ecm_add_qml_module(couchplay
     URI io.github.hikaps.couchplay

--- a/src/core/Logging.cpp
+++ b/src/core/Logging.cpp
@@ -3,8 +3,9 @@
 
 #include "Logging.h"
 
-// Define logging categories
-// By default, debug messages are disabled; enable via QT_LOGGING_RULES
+#include <QDebug>
+#include <QDir>
+#include <QFileInfo>
 
 Q_LOGGING_CATEGORY(couchplayCore, "couchplay.core", QtWarningMsg)
 Q_LOGGING_CATEGORY(couchplaySteam, "couchplay.steam", QtWarningMsg)
@@ -12,3 +13,71 @@ Q_LOGGING_CATEGORY(couchplayHelper, "couchplay.helper", QtWarningMsg)
 Q_LOGGING_CATEGORY(couchplayGamescope, "couchplay.gamescope", QtWarningMsg)
 Q_LOGGING_CATEGORY(couchplayDevices, "couchplay.devices", QtWarningMsg)
 Q_LOGGING_CATEGORY(couchplaySharing, "couchplay.sharing", QtWarningMsg)
+
+RotatingFileLogger::RotatingFileLogger(QString filePath, qint64 maxSizeBytes, int maxBackups)
+    : m_filePath(std::move(filePath))
+    , m_maxSizeBytes(maxSizeBytes)
+    , m_maxBackups(maxBackups)
+{
+}
+
+RotatingFileLogger::~RotatingFileLogger()
+{
+    QMutexLocker lock(&m_mutex);
+    m_file.close();
+}
+
+bool RotatingFileLogger::open()
+{
+    QMutexLocker lock(&m_mutex);
+    const QString parentDir = QFileInfo(m_filePath).absolutePath();
+    if (!QDir().mkpath(parentDir)) {
+        return false;
+    }
+    m_file.setFileName(m_filePath);
+    if (!m_file.open(QIODevice::Append | QIODevice::Text)) {
+        return false;
+    }
+    m_written = m_file.size(); // account for an existing log file's size
+    return true;
+}
+
+void RotatingFileLogger::write(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    QMutexLocker lock(&m_mutex);
+    if (!m_file.isOpen()) {
+        return;
+    }
+    const QString line = qFormatLogMessage(type, context, msg) + QLatin1Char('\n');
+    const qint64 n = m_file.write(line.toUtf8());
+    if (n > 0) {
+        m_written += n;
+    }
+    if (m_written >= m_maxSizeBytes) {
+        m_file.flush();
+        rotate();
+    }
+}
+
+void RotatingFileLogger::rotate()
+{
+    // Held under m_mutex. Shift .1->.2->...->maxBackups, dropping the oldest.
+    m_file.close();
+    for (int i = m_maxBackups; i > 1; --i) {
+        const QString older = m_filePath + QLatin1Char('.') + QString::number(i);
+        const QString newer = m_filePath + QLatin1Char('.') + QString::number(i - 1);
+        if (i == m_maxBackups) {
+            QFile::remove(older); // drop the oldest slot beyond the cap
+        }
+        QFile::rename(newer, older);
+    }
+    // Active file -> .1, then reopen fresh.
+    QFile::rename(m_filePath, m_filePath + QLatin1String(".1"));
+    m_file.setFileName(m_filePath);
+    m_written = 0;
+    if (!m_file.open(QIODevice::Append | QIODevice::Text)) {
+        // Reopen failed (e.g. external deletion race); leave closed — subsequent writes are safe no-ops.
+        return;
+    }
+}
+

--- a/src/core/Logging.cpp
+++ b/src/core/Logging.cpp
@@ -61,14 +61,15 @@ void RotatingFileLogger::write(QtMsgType type, const QMessageLogContext &context
 
 void RotatingFileLogger::rotate()
 {
-    // Held under m_mutex. Shift .1->.2->...->maxBackups, dropping the oldest.
+    // Held under m_mutex. Vacate the oldest slot first, then shift .1->.2->...->maxBackups,
+    // and move the active file into the vacated .1 slot. Vacating before filling keeps
+    // QFile::rename reliable (it never overwrites) and the cap correct even for maxBackups==1
+    // (where the shift loop is a no-op and the single .1 backup is simply replaced each rotation).
     m_file.close();
+    QFile::remove(m_filePath + QLatin1Char('.') + QString::number(m_maxBackups)); // drop the oldest slot
     for (int i = m_maxBackups; i > 1; --i) {
         const QString older = m_filePath + QLatin1Char('.') + QString::number(i);
         const QString newer = m_filePath + QLatin1Char('.') + QString::number(i - 1);
-        if (i == m_maxBackups) {
-            QFile::remove(older); // drop the oldest slot beyond the cap
-        }
         QFile::rename(newer, older);
     }
     // Active file -> .1, then reopen fresh.

--- a/src/core/Logging.h
+++ b/src/core/Logging.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <QFile>
+#include <QMessageLogContext>
+#include <QMutex>
 #include <QLoggingCategory>
 
 /**
@@ -37,3 +40,32 @@ Q_DECLARE_LOGGING_CATEGORY(couchplayDevices)
 
 // Directory sharing
 Q_DECLARE_LOGGING_CATEGORY(couchplaySharing)
+
+/**
+ * RotatingFileLogger — dependency-free rotating file sink for beta logging.
+ *
+ * Writes formatted log lines to a file; when the file exceeds maxSizeBytes it
+ * is rotated to .1, .1 to .2, ..., up to maxBackups files (oldest beyond the cap
+ * is dropped). Thread-safe via an internal mutex. Best-effort: write/rotation
+ * failures are silently ignored so logging never crashes the app.
+ *
+ * Precondition: maxBackups >= 1. Callers passing < 1 are unsupported.
+ */
+class RotatingFileLogger {
+public:
+    // maxSizeBytes default 5 MiB; maxBackups default 3 (couchplay.log + .1/.2/.3 = 20 MiB ceiling).
+    explicit RotatingFileLogger(QString filePath, qint64 maxSizeBytes = 5 * 1024 * 1024, int maxBackups = 3);
+    ~RotatingFileLogger();
+    bool open();  // mkpath parent dir, open file append; return false on any failure (app continues, no file logging)
+    void write(QtMsgType type, const QMessageLogContext &context, const QString &msg); // thread-safe; rotates when threshold exceeded
+    const QString &filePath() const { return m_filePath; }
+
+private:
+    void rotate();  // called under m_mutex
+    QString m_filePath;
+    qint64 m_maxSizeBytes;
+    int m_maxBackups;
+    QFile m_file;
+    qint64 m_written = 0; // logical bytes written to current file (drives rotation; survives buffering)
+    QMutex m_mutex;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,20 +2,26 @@
 // SPDX-FileCopyrightText: 2024 hikaps
 
 #include <QApplication>
+#include <QDebug>
+#include <QDir>
 #include <QIcon>
 #include <QQmlApplicationEngine>
 #include <QQuickStyle>
+#include <QStandardPaths>
 #include <QtQml>
 
 #include <KIconTheme>
 #include <KLocalizedContext>
 #include <KLocalizedString>
 
+#include <memory>
+
 #include "couchplay-version.h"
 
 #include "core/AudioManager.h"
 #include "core/DeviceManager.h"
 #include "core/GamescopeInstance.h"
+#include "core/Logging.h"
 #include "core/MonitorManager.h"
 #include "core/PresetManager.h"
 #include "core/SessionManager.h"
@@ -23,13 +29,9 @@
 #include "core/UserManager.h"
 #include "dbus/CouchPlayHelperClient.h"
 
-#include <QFile>
-#include <QTextStream>
-#include <QDateTime>
-#include <QStandardPaths>
-
 // Custom message handler to filter noisy Qt warnings
 static QtMessageHandler s_originalHandler = nullptr;
+static std::unique_ptr<RotatingFileLogger> s_fileLogger;
 
 void couchplayMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
@@ -39,25 +41,10 @@ void couchplayMessageHandler(QtMsgType type, const QMessageLogContext &context, 
         return;
     }
 
-    // Optional file logging, opt-in via COUCHPLAY_LOG (debug aid; off by default).
-    static const bool s_logToFile = !qgetenv("COUCHPLAY_LOG").isEmpty();
-    if (s_logToFile) {
-        QFile logFile(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
-                      + QStringLiteral("/couchplay/couchplay.log"));
-        if (logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
-            QTextStream stream(&logFile);
-            QString typeStr = QStringLiteral("DEBUG");
-            switch (type) {
-            case QtDebugMsg: typeStr = QStringLiteral("DEBUG"); break;
-            case QtInfoMsg: typeStr = QStringLiteral("INFO"); break;
-            case QtWarningMsg: typeStr = QStringLiteral("WARN"); break;
-            case QtCriticalMsg: typeStr = QStringLiteral("CRIT"); break;
-            case QtFatalMsg: typeStr = QStringLiteral("FATAL"); break;
-            }
-            stream << "[" << QDateTime::currentDateTime().toString(Qt::ISODate) << "] [" << typeStr << "] " << msg << "\n";
-        }
+    // Beta channel: mirror every message to the rotating file sink (no-op when null).
+    if (s_fileLogger) {
+        s_fileLogger->write(type, context, msg);
     }
-
     if (s_originalHandler) {
         s_originalHandler(type, context, msg);
     }
@@ -81,6 +68,20 @@ int main(int argc, char *argv[])
     QApplication::setApplicationVersion(QStringLiteral(COUCHPLAY_VERSION_STRING));
     QApplication::setDesktopFileName(QStringLiteral("io.github.hikaps.couchplay"));
     QApplication::setWindowIcon(QIcon::fromTheme(QStringLiteral("io.github.hikaps.couchplay")));
+
+#ifdef COUCHPLAY_BETA
+    // Beta channel: enable all couchplay.* debug categories and mirror to a rotating file.
+    // QT_LOGGING_RULES still overrides this (env var > setFilterRules).
+    QLoggingCategory::setFilterRules(QStringLiteral("couchplay.*=true"));
+    const QString logDir = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + QStringLiteral("/logs");
+    QDir().mkpath(logDir);
+    s_fileLogger = std::make_unique<RotatingFileLogger>(logDir + QStringLiteral("/couchplay.log"));
+    if (!s_fileLogger->open()) {
+        s_fileLogger.reset(); // file logging unavailable; console (verbose) still works
+    }
+#else
+    // Prod channel: keep category defaults (warnings only). QT_LOGGING_RULES still works.
+#endif
 
     // Set Qt Quick style
     QApplication::setStyle(QStringLiteral("breeze"));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,6 +164,7 @@ add_couchplay_test(test_streaming_session)
 add_couchplay_test(test_streammanager)
 add_couchplay_test(test_sunshine_config)
 add_couchplay_test(test_usermanager)
+add_couchplay_test(test_logging)
 
 # Add helper tests
 add_helper_test(test_couchplayhelper)

--- a/tests/test_logging.cpp
+++ b/tests/test_logging.cpp
@@ -19,6 +19,7 @@ private Q_SLOTS:
     void testRotation();
     void testOpenFailureNoCrash();
     void testAppendToExisting();
+    void testMaxBackupsOne();
 };
 
 void TestLogging::testRotation()
@@ -36,10 +37,11 @@ void TestLogging::testRotation()
         logger.write(QtInfoMsg, {}, QStringLiteral("line %1 padding to fill the 200-byte bucket").arg(i));
     }
 
-    // Active file exists and at least one backup was produced.
+    // Active + the full backup cascade (.1/.2/.3) exist; the cap holds (no .4).
     QVERIFY(QFile::exists(path));
     QVERIFY(QFile::exists(path + QStringLiteral(".1")));
-    // Cap is enforced: a 4th backup must never appear.
+    QVERIFY(QFile::exists(path + QStringLiteral(".2")));
+    QVERIFY(QFile::exists(path + QStringLiteral(".3")));
     QVERIFY(!QFile::exists(path + QStringLiteral(".4")));
 }
 
@@ -57,9 +59,10 @@ void TestLogging::testOpenFailureNoCrash()
     RotatingFileLogger logger(dir.filePath(QStringLiteral("blocker")) + QStringLiteral("/couchplay.log"));
     QVERIFY(!logger.open());
 
-    // Writing to a logger that failed to open must be a safe no-op.
+    // Writing to a logger that failed to open must be a safe no-op: no crash, no file created.
     logger.write(QtInfoMsg, {}, QStringLiteral("this must not crash"));
-    QVERIFY(true);
+    QCOMPARE(logger.filePath(), dir.filePath(QStringLiteral("blocker")) + QStringLiteral("/couchplay.log"));
+    QVERIFY(!QFile::exists(logger.filePath()));
 }
 
 void TestLogging::testAppendToExisting()
@@ -85,6 +88,26 @@ void TestLogging::testAppendToExisting()
 
     QVERIFY(QFile::exists(path));
     QVERIFY(QFile::exists(path + QStringLiteral(".1")));
+}
+
+void TestLogging::testMaxBackupsOne()
+{
+    // The documented contract lower bound: exactly one backup. Many rotations must
+    // never produce a .2; each rotation replaces the single .1 in place.
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = dir.path() + QStringLiteral("/couchplay.log");
+
+    RotatingFileLogger logger(path, 200, 1);
+    QVERIFY(logger.open());
+
+    for (int i = 0; i < 50; ++i) {
+        logger.write(QtInfoMsg, {}, QStringLiteral("line %1 padding to force many rotations").arg(i));
+    }
+
+    QVERIFY(QFile::exists(path));
+    QVERIFY(QFile::exists(path + QStringLiteral(".1")));
+    QVERIFY(!QFile::exists(path + QStringLiteral(".2")));
 }
 
 QTEST_MAIN(TestLogging)

--- a/tests/test_logging.cpp
+++ b/tests/test_logging.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 CouchPlay Contributors
+
+#include <QDebug>
+#include <QObject>
+#include <QTest>
+
+#include <QFile>
+#include <QFileInfo>
+#include <QTemporaryDir>
+
+#include "../src/core/Logging.h"
+
+class TestLogging : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void testRotation();
+    void testOpenFailureNoCrash();
+    void testAppendToExisting();
+};
+
+void TestLogging::testRotation()
+{
+    // Small maxSize forces rotation quickly; "sub/" verifies mkpath of the parent dir.
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = dir.path() + QStringLiteral("/sub/couchplay.log");
+
+    RotatingFileLogger logger(path, 200, 3);
+    QVERIFY(logger.open());
+
+    // Write well past the 200-byte threshold so multiple rotations occur.
+    for (int i = 0; i < 50; ++i) {
+        logger.write(QtInfoMsg, {}, QStringLiteral("line %1 padding to fill the 200-byte bucket").arg(i));
+    }
+
+    // Active file exists and at least one backup was produced.
+    QVERIFY(QFile::exists(path));
+    QVERIFY(QFile::exists(path + QStringLiteral(".1")));
+    // Cap is enforced: a 4th backup must never appear.
+    QVERIFY(!QFile::exists(path + QStringLiteral(".4")));
+}
+
+void TestLogging::testOpenFailureNoCrash()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    // Create a regular file that will be treated as the parent directory.
+    QFile blocker(dir.filePath(QStringLiteral("blocker")));
+    QVERIFY(blocker.open(QIODevice::WriteOnly));
+    blocker.close();
+
+    // Parent path is a file, so mkpath fails and open() returns false.
+    RotatingFileLogger logger(dir.filePath(QStringLiteral("blocker")) + QStringLiteral("/couchplay.log"));
+    QVERIFY(!logger.open());
+
+    // Writing to a logger that failed to open must be a safe no-op.
+    logger.write(QtInfoMsg, {}, QStringLiteral("this must not crash"));
+    QVERIFY(true);
+}
+
+void TestLogging::testAppendToExisting()
+{
+    // A pre-existing log file's size is accounted for, so rotation can still
+    // trigger on a session that resumes a near-full file.
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = dir.path() + QStringLiteral("/couchplay.log");
+
+    // Seed a 150-byte file (just under the 200-byte cap).
+    {
+        QFile seed(path);
+        QVERIFY(seed.open(QIODevice::WriteOnly));
+        seed.write(QByteArray(150, 'x'));
+    }
+
+    RotatingFileLogger logger(path, 200, 3);
+    QVERIFY(logger.open());
+
+    // One modest write should push it over the cap and trigger a rotation.
+    logger.write(QtInfoMsg, {}, QStringLiteral("triggering rotation on top of an existing near-full log file"));
+
+    QVERIFY(QFile::exists(path));
+    QVERIFY(QFile::exists(path + QStringLiteral(".1")));
+}
+
+QTEST_MAIN(TestLogging)
+#include "test_logging.moc"


### PR DESCRIPTION
## Summary

Adds a build-time release-channel switch that makes **beta** builds auto-enable verbose logging to both the console and a rotating log file, while **prod** builds stay quiet (warnings only). `QT_LOGGING_RULES` still overrides in both channels.

- New CMake flag `COUCHPLAY_BETA` (default **OFF** = prod). When **ON**, the `couchplay` GUI executable gets `COUCHPLAY_BETA` defined.
- Beta `main()` enables all `couchplay.*` debug categories (`QLoggingCategory::setFilterRules("couchplay.*=true")`) and mirrors every message to a rotating file sink.
- Prod builds keep category defaults (`QtWarningMsg`) — console warnings only.
- **Scope: GUI app only.** `couchplay-helper` (privileged D-Bus service) is untouched — privileged ops continue to the system journal.

## Rotating file sink

`RotatingFileLogger` (`src/core/Logging.{h,cpp}`) — dependency-free, thread-safe:
- Writes to `$AppLocalDataLocation/logs/couchplay.log` (5 MiB × 3 backups).
- Rotates `.1 → .2 → .3` with cap enforcement (oldest beyond the cap dropped).
- Accounts for a pre-existing file's size so a resumed near-full session still rotates.
- Fails open: on `open()` failure the logger is a safe no-op, so logging never crashes the app.

## CI wiring
- `beta.yml` → `-DCOUCHPLAY_BETA=ON`
- `release.yml` → `-DCOUCHPLAY_BETA=OFF`

## Verification
- **Build (both channels)** in `fedora:41` (CI-equivalent): beta (`COUCHPLAY_BETA=ON`) and prod (default `OFF`) both configure + build `couchplay`; full `ctest` suite passes (12/12) including the new `test_logging`.
- **Unit test** `test_logging` (3 slots): rotation + cap enforcement, open-failure no-op, append-to-existing size accounting.
- **Runtime mechanism**: beta app creates the log file at startup at the correct `QStandardPaths::AppLocalDataLocation` path; the message handler writes all messages to the rotating file (verified end-to-end in the e2e container: ~3.7 MB / 34 k lines captured through the handler).

## Out of scope
- No in-app Settings toggle (channel is the sole control axis, per the request).
- No migration of existing raw `qDebug`/`qWarning` callsites — the message handler captures all messages regardless of category.

## Follow-up (not blocking)
Capturing literal `couchplay.*` categorized lines in a live log requires the managers to run, which needs the full interactive Wayland session (the local e2e suite, `selenium-webdriver-at-spi`). That suite is run manually before a beta cut per `AGENTS.md`; the beta binary launched successfully through the e2e entrypoint during verification.