### PR TITLE
fix(install): bundle helper libs for Arch/SteamOS (#28, #37) + regression guard

### DIFF
--- a/.github/workflows/arch-smoke.yml
+++ b/.github/workflows/arch-smoke.yml
@@ -48,11 +48,7 @@ jobs:
             cmake --build build --parallel "$(nproc)" --target couchplay-helper
             rm -rf smoke && mkdir -p smoke/bin
             cp build/bin/couchplay-helper smoke/bin/
-            chmod +x scripts/bundle-libs.sh
-            ./scripts/bundle-libs.sh smoke/bin/couchplay-helper lib/couchplay
-            # Packaging assertion (#28/#37): bundling must land.
-            test -f smoke/lib/couchplay/libQt6Core.so.6
-            patchelf --print-rpath smoke/bin/couchplay-helper | grep -q "lib/couchplay"
+            ./scripts/package-helper.sh smoke/bin/couchplay-helper
           '
 
       - name: Load helper in Arch (positive + negative control)

--- a/.github/workflows/arch-smoke.yml
+++ b/.github/workflows/arch-smoke.yml
@@ -23,8 +23,6 @@ name: Packaging Smoke (Arch)
 on:
   push:
     branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/arch-smoke.yml
+++ b/.github/workflows/arch-smoke.yml
@@ -67,7 +67,7 @@ jobs:
               ldd smoke/bin/couchplay-helper | grep -i qt6core
               exit 1
             fi
-            out="$(timeout 3 smoke/bin/couchplay-helper 2>&1 || true)"
+            out="$(timeout -k 2 3 smoke/bin/couchplay-helper 2>&1 || true)"
             if printf "%s" "$out" | grep -qi "copy relocation\|INDIRECT_EXTERN_ACCESS"; then
               echo "::error::bundled helper hit the copy-relocation error"
               printf "%s\n" "$out"
@@ -79,9 +79,15 @@ jobs:
             mkdir -p /tmp/neg
             cp smoke/bin/couchplay-helper /tmp/neg/couchplay-helper
             patchelf --remove-rpath /tmp/neg/couchplay-helper
-            neg="$(timeout 3 /tmp/neg/couchplay-helper 2>&1 || true)"
+            neg="$(timeout -k 2 3 /tmp/neg/couchplay-helper 2>&1 || true)"
             if printf "%s" "$neg" | grep -qi "copy relocation\|INDIRECT_EXTERN_ACCESS"; then
               echo "PASS: negative control reproduced the expected copy-relocation error"
+            elif printf "%s" "$neg" | grep -qi "cannot open shared object file"; then
+              echo "::error::negative control failed with a MISSING dependency, not the copy-relocation error."
+              echo "The helper gained a runtime lib not in qt6-base/polkit-qt6 -- add it to the pacman"
+              echo "install above, or this control can no longer verify the regression."
+              printf "%s\n" "$neg"
+              exit 1
             else
               echo "::error::negative control did NOT reproduce the copy-relocation error."
               echo "Qt/glibc changed and this test is no longer meaningful -- revisit it."

--- a/.github/workflows/arch-smoke.yml
+++ b/.github/workflows/arch-smoke.yml
@@ -36,12 +36,7 @@ jobs:
         run: |
           docker run --rm -v "$PWD:/src" -w /src fedora:41 bash -lc '
             set -euo pipefail
-            dnf install -y cmake gcc-c++ git make \
-              qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qt5compat-devel \
-              kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
-              kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
-              kf6-kglobalaccel-devel extra-cmake-modules \
-              pipewire-devel polkit-devel polkit-qt6-1-devel patchelf binutils
+            ./scripts/install-build-deps.sh patchelf binutils
             cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
             cmake --build build --parallel "$(nproc)" --target couchplay-helper
             rm -rf smoke && mkdir -p smoke/bin

--- a/.github/workflows/arch-smoke.yml
+++ b/.github/workflows/arch-smoke.yml
@@ -1,0 +1,91 @@
+name: Packaging Smoke (Arch)
+
+# Regression guard for the helper's runtime-library bundling (#28, #37).
+#
+# The copy-relocation failure (exit 127, "error due to
+# GNU_PROPERTY_1_NEEDED_INDIRECT_EXTERN_ACCESS") only manifests when a
+# Fedora-built helper is loaded against Arch's Qt6Core (built with
+# -fno-semantic-interposition). The unit-test suite runs on Fedora, so it
+# CANNOT reproduce this -- a green unit run gives false confidence. This
+# workflow builds the helper on Fedora, bundles its libs (as beta/release do),
+# then loads it in an archlinux container and checks:
+#   1. POSITIVE -- the bundled helper resolves Qt6Core to the bundle and runs
+#      with no copy-relocation error.
+#   2. NEGATIVE CONTROL -- an un-bundled copy MUST still reproduce the error.
+#      The control is what makes the test trustworthy: if it ever stops
+#      erroring, the test is no longer meaningful (Qt/glibc changed) and must be
+#      revisited, not silently ignored.
+#
+# Runs on GitHub-hosted ubuntu (Docker available, no host GPU/Wayland needed --
+# this is pure ELF load behaviour). Plain archlinux is a faithful proxy for
+# CachyOS/SteamOS: both reporters (#28, #37) hit the byte-identical error.
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+jobs:
+  arch-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build + bundle the helper on Fedora (mirrors release.yml)
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src fedora:41 bash -lc '
+            set -euo pipefail
+            dnf install -y cmake gcc-c++ git make \
+              qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qt5compat-devel \
+              kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
+              kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
+              kf6-kglobalaccel-devel extra-cmake-modules \
+              pipewire-devel polkit-devel polkit-qt6-1-devel patchelf binutils
+            cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
+            cmake --build build --parallel "$(nproc)" --target couchplay-helper
+            rm -rf smoke && mkdir -p smoke/bin
+            cp build/bin/couchplay-helper smoke/bin/
+            chmod +x scripts/bundle-libs.sh
+            ./scripts/bundle-libs.sh smoke/bin/couchplay-helper lib/couchplay
+            # Packaging assertion (#28/#37): bundling must land.
+            test -f smoke/lib/couchplay/libQt6Core.so.6
+            patchelf --print-rpath smoke/bin/couchplay-helper | grep -q "lib/couchplay"
+          '
+
+      - name: Load helper in Arch (positive + negative control)
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src archlinux:latest bash -lc '
+            set -euo pipefail
+            pacman -Sy --noconfirm --needed qt6-base polkit-qt6 patchelf
+
+            echo "=== POSITIVE: bundled helper must load the bundled Fedora Qt6Core ==="
+            if ldd smoke/bin/couchplay-helper 2>&1 | grep -q "/usr/lib/libQt6Core"; then
+              echo "::error::bundled helper resolved Qt6Core to the SYSTEM lib, not the bundle"
+              ldd smoke/bin/couchplay-helper | grep -i qt6core
+              exit 1
+            fi
+            out="$(timeout 3 smoke/bin/couchplay-helper 2>&1 || true)"
+            if printf "%s" "$out" | grep -qi "copy relocation\|INDIRECT_EXTERN_ACCESS"; then
+              echo "::error::bundled helper hit the copy-relocation error"
+              printf "%s\n" "$out"
+              exit 1
+            fi
+            echo "PASS: bundled helper loads on Arch without the copy-relocation error"
+
+            echo "=== NEGATIVE CONTROL: un-bundled copy MUST reproduce the error ==="
+            mkdir -p /tmp/neg
+            cp smoke/bin/couchplay-helper /tmp/neg/couchplay-helper
+            patchelf --remove-rpath /tmp/neg/couchplay-helper
+            neg="$(timeout 3 /tmp/neg/couchplay-helper 2>&1 || true)"
+            if printf "%s" "$neg" | grep -qi "copy relocation\|INDIRECT_EXTERN_ACCESS"; then
+              echo "PASS: negative control reproduced the expected copy-relocation error"
+            else
+              echo "::error::negative control did NOT reproduce the copy-relocation error."
+              echo "Qt/glibc changed and this test is no longer meaningful -- revisit it."
+              printf "%s\n" "$neg"
+              exit 1
+            fi
+          '

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -50,13 +50,8 @@ jobs:
           cp build/bin/couchplay release-appdir/bin/
           cp build/bin/couchplay-helper release-appdir/bin/
 
-          # Bundle the helper's runtime libraries so it runs without system Qt6/Polkit
-          chmod +x scripts/bundle-libs.sh
-          ./scripts/bundle-libs.sh release-appdir/bin/couchplay-helper lib/couchplay
-          # Regression guard (#28/#37): bundling must land, else the helper
-          # falls back to system Qt6Core on Arch/SteamOS (copy-relocation reject).
-          test -f release-appdir/lib/couchplay/libQt6Core.so.6 || { echo "::error::bundled libQt6Core.so.6 missing"; exit 1; }
-          patchelf --print-rpath release-appdir/bin/couchplay-helper | grep -q 'lib/couchplay' || { echo "::error::helper RPATH not set to bundled libs"; exit 1; }
+          # Bundle the helper's runtime libs + assert the bundle landed (#28/#37).
+          ./scripts/package-helper.sh release-appdir/bin/couchplay-helper
 
           # Copy scripts
           cp scripts/install-helper.sh release-appdir/

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -21,7 +21,7 @@ jobs:
             kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
             kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
             kf6-kglobalaccel-devel extra-cmake-modules \
-            pipewire-devel polkit-devel polkit-qt6-1-devel
+            pipewire-devel polkit-devel polkit-qt6-1-devel patchelf
 
       - uses: actions/checkout@v4
         with:
@@ -49,6 +49,10 @@ jobs:
           # Copy binaries
           cp build/bin/couchplay release-appdir/bin/
           cp build/bin/couchplay-helper release-appdir/bin/
+
+          # Bundle the helper's runtime libraries so it runs without system Qt6/Polkit
+          chmod +x scripts/bundle-libs.sh
+          ./scripts/bundle-libs.sh release-appdir/bin/couchplay-helper lib/couchplay
 
           # Copy scripts
           cp scripts/install-helper.sh release-appdir/

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -53,6 +53,10 @@ jobs:
           # Bundle the helper's runtime libraries so it runs without system Qt6/Polkit
           chmod +x scripts/bundle-libs.sh
           ./scripts/bundle-libs.sh release-appdir/bin/couchplay-helper lib/couchplay
+          # Regression guard (#28/#37): bundling must land, else the helper
+          # falls back to system Qt6Core on Arch/SteamOS (copy-relocation reject).
+          test -f release-appdir/lib/couchplay/libQt6Core.so.6 || { echo "::error::bundled libQt6Core.so.6 missing"; exit 1; }
+          patchelf --print-rpath release-appdir/bin/couchplay-helper | grep -q 'lib/couchplay' || { echo "::error::helper RPATH not set to bundled libs"; exit 1; }
 
           # Copy scripts
           cp scripts/install-helper.sh release-appdir/

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -14,14 +14,8 @@ jobs:
     container:
       image: fedora:41
     steps:
-      - name: Install dependencies
-        run: |
-          dnf install -y cmake gcc-c++ git make tar \
-            qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qt5compat-devel \
-            kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
-            kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
-            kf6-kglobalaccel-devel extra-cmake-modules \
-            pipewire-devel polkit-devel polkit-qt6-1-devel patchelf
+      - name: Install git (required before checkout on a bare fedora:41 image)
+        run: dnf install -y git
 
       - uses: actions/checkout@v4
         with:
@@ -29,6 +23,9 @@ jobs:
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory /__w/couchplay/couchplay
+
+      - name: Install build dependencies
+        run: ./scripts/install-build-deps.sh tar patchelf
 
       - name: Configure CMake
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,16 @@ jobs:
     container:
       image: fedora:41
     steps:
-      - name: Install dependencies
-        run: |
-          dnf install -y cmake gcc-c++ git make \
-            qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qt5compat-devel \
-            kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
-            kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
-            kf6-kglobalaccel-devel extra-cmake-modules \
-            pipewire-devel polkit-devel polkit-qt6-1-devel dbus-daemon
+      - name: Install git (required before checkout on a bare fedora:41 image)
+        run: dnf install -y git
 
       - uses: actions/checkout@v4
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory /__w/couchplay/couchplay
+
+      - name: Install build dependencies
+        run: ./scripts/install-build-deps.sh dbus-daemon
 
       - name: Configure CMake
         run: cmake -B build -DBUILD_TESTING=ON

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,10 @@ jobs:
           # Bundle the helper's runtime libraries so it runs without system Qt6/Polkit
           chmod +x scripts/bundle-libs.sh
           ./scripts/bundle-libs.sh release-appdir/bin/couchplay-helper lib/couchplay
+          # Regression guard (#28/#37): bundling must land, else the helper
+          # falls back to system Qt6Core on Arch/SteamOS (copy-relocation reject).
+          test -f release-appdir/lib/couchplay/libQt6Core.so.6 || { echo "::error::bundled libQt6Core.so.6 missing"; exit 1; }
+          patchelf --print-rpath release-appdir/bin/couchplay-helper | grep -q 'lib/couchplay' || { echo "::error::helper RPATH not set to bundled libs"; exit 1; }
 
           # Copy scripts
           cp scripts/install-helper.sh release-appdir/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,8 @@ jobs:
     container:
       image: fedora:41
     steps:
-      - name: Install dependencies
-        run: |
-          dnf install -y cmake gcc-c++ git make tar \
-            qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qt5compat-devel \
-            kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
-            kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
-            kf6-kglobalaccel-devel extra-cmake-modules \
-            pipewire-devel polkit-devel polkit-qt6-1-devel patchelf
+      - name: Install git (required before checkout on a bare fedora:41 image)
+        run: dnf install -y git
 
       - uses: actions/checkout@v4
         with:
@@ -30,6 +24,9 @@ jobs:
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory /__w/couchplay/couchplay
+
+      - name: Install build dependencies
+        run: ./scripts/install-build-deps.sh tar patchelf
 
       - name: Verify tag is on main branch
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,8 @@ jobs:
           cp build/bin/couchplay release-appdir/bin/
           cp build/bin/couchplay-helper release-appdir/bin/
 
-          # Bundle the helper's runtime libraries so it runs without system Qt6/Polkit
-          chmod +x scripts/bundle-libs.sh
-          ./scripts/bundle-libs.sh release-appdir/bin/couchplay-helper lib/couchplay
-          # Regression guard (#28/#37): bundling must land, else the helper
-          # falls back to system Qt6Core on Arch/SteamOS (copy-relocation reject).
-          test -f release-appdir/lib/couchplay/libQt6Core.so.6 || { echo "::error::bundled libQt6Core.so.6 missing"; exit 1; }
-          patchelf --print-rpath release-appdir/bin/couchplay-helper | grep -q 'lib/couchplay' || { echo "::error::helper RPATH not set to bundled libs"; exit 1; }
+          # Bundle the helper's runtime libs + assert the bundle landed (#28/#37).
+          ./scripts/package-helper.sh release-appdir/bin/couchplay-helper
 
           # Copy scripts
           cp scripts/install-helper.sh release-appdir/

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 CouchPlay Contributors
+#
+# Install CouchPlay's Fedora build dependencies.
+#
+# Single source of truth for the dnf package list so it can't drift across the
+# ci / beta / release / arch-smoke workflows (the divergence class that bit
+# #28/#37). The core list lives here; each caller passes only the few extra
+# packages it uniquely needs:
+#   ci:          install-build-deps.sh dbus-daemon
+#   beta/release: install-build-deps.sh tar patchelf
+#   arch-smoke:  install-build-deps.sh patchelf binutils
+#
+# Run on Fedora (provides dnf). Note: the build workflows install git before
+# `actions/checkout` (the bare fedora:41 image lacks it); git is also in the
+# core list below, so the second install is an idempotent no-op there.
+set -euo pipefail
+
+dnf install -y \
+  cmake gcc-c++ git make \
+  qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qt5compat-devel \
+  kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel \
+  kf6-kconfig-devel kf6-kiconthemes-devel kf6-qqc2-desktop-style \
+  kf6-kglobalaccel-devel extra-cmake-modules \
+  pipewire-devel polkit-devel polkit-qt6-1-devel \
+  "$@"

--- a/scripts/package-helper.sh
+++ b/scripts/package-helper.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 CouchPlay Contributors
+#
+# Bundle the helper's runtime libraries and assert the bundle landed.
+#
+# Shared by the beta/release publish workflows and the arch-smoke test so the
+# packaging sequence has a single source of truth and can't silently drift
+# between them -- the divergence that let beta ship without bundling (#28/#37).
+#
+# Usage: package-helper.sh <binary> [librel]
+#   binary : helper ELF to bundle (processed in place)
+#   librel : lib dir relative to $ORIGIN/.. (default: lib/couchplay); passed
+#            through to bundle-libs.sh
+# Requires: patchelf, and bundle-libs.sh as a sibling of this script.
+set -euo pipefail
+
+bin="${1:?usage: package-helper.sh <binary> [librel]}"
+librel="${2:-lib/couchplay}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bundle="$here/bundle-libs.sh"
+chmod +x "$bundle"
+
+# Bundle the runtime libs: ships the build-env Qt6Core next to the binary so the
+# helper doesn't fall back to a system Qt6Core on Arch/SteamOS.
+"$bundle" "$bin" "$librel"
+
+# Regression guard (#28/#37): the bundle must land and the helper must point at
+# it, else the binary loads a system libQt6Core.so.6 that glibc rejects via
+# GNU_PROPERTY_1_NEEDED_INDIRECT_EXTERN_ACCESS (service exit 127).
+libdir="$(dirname "$bin")/../$librel"
+if [[ ! -f "$libdir/libQt6Core.so.6" ]]; then
+    echo "::error::bundled libQt6Core.so.6 missing under $libdir"
+    exit 1
+fi
+rpath="$(patchelf --print-rpath "$bin")"
+if [[ "$rpath" != *"$librel"* ]]; then
+    echo "::error::helper RPATH '$rpath' does not reference the bundled libs ($librel)"
+    exit 1
+fi
+echo "[package-helper] OK: libQt6Core.so.6 bundled, RPATH=$rpath"


### PR DESCRIPTION
## Problem

`couchplay-helper.service` fails to start on Arch-based distros (CachyOS #28, SteamOS #37) with two errors:

1. **`status=226/NAMESPACE`** — `/var/home: No such file or directory` (Bazzite-specific path in the unit). **Already fixed on develop** (`ReadWritePaths=-/var/home`); #28's latest journal confirms the namespace step now passes.
2. **`status=127`** — copy-relocation rejection:
   ```
   warning: copy relocation against non-copyable protected symbol `_ZN9QtPrivate25QMetaTypeInterfaceWrapperIxE8metaTypeE' in `/usr/lib/libQt6Core.so.6'
   ...: error due to GNU_PROPERTY_1_NEEDED_INDIRECT_EXTERN_ACCESS
   ```

## Root cause (#2)

The helper is built on the `fedora:41` CI container. Arch/SteamOS Qt6Core is built with `-fno-semantic-interposition` and carries `GNU_PROPERTY_1_NEEDED_INDIRECT_EXTERN_ACCESS`, so glibc rejects the binary's copy relocation. `scripts/bundle-libs.sh` ships the matching Fedora Qt6Core next to the binary (`$ORIGIN/../lib/couchplay` RPATH) so runtime Qt == link-time Qt — but **`beta.yml` never invoked it** (and didn't install `patchelf`). Every failing log named `/usr/lib/libQt6Core.so.6` = the system lib, proving no bundling reached users.

## Changes

- **`beta.yml`** — add `patchelf` to deps; invoke `bundle-libs.sh` on the helper (parity with `release.yml`).
- **`beta.yml` + `release.yml`** — packaging assertion: after bundling, assert `lib/couchplay/libQt6Core.so.6` exists and the helper RPATH is set.
- **`arch-smoke.yml`** (new) — cross-distro regression guard. Builds the helper on Fedora, bundles, then loads it in an `archlinux` container: **positive** (bundled helper loads, no copy-relocation error) + **negative control** (un-bundled copy must still reproduce the error). Unit tests can't catch this — they run on Fedora where the helper loads fine regardless of bundling.

## Verification

Reproduced the exact reported error and proved the fix end-to-end via a Fedora↔Arch A/B container test driven through the host's podman socket:

**Control (un-bundled beta helper, Arch Qt6Core):**
```
warning: copy relocation against non-copyable protected symbol `_ZN9QtPrivate25QMetaTypeInterfaceWrapperIxE8metaTypeE' in `/usr/lib/libQt6Core.so.6'
...: error due to GNU_PROPERTY_1_NEEDED_INDIRECT_EXTERN_ACCESS   EXIT=127
```
**Fix (bundled Fedora Qt6Core):**
```
ldd: libQt6Core.so.6 => .../lib/couchplay/libQt6Core.so.6   (Fedora, not /usr/lib)
run: EXIT=1   ← loaded cleanly; no copy-relocation error
```

Closes #28. Closes #37.