### PR TITLE
ci(e2e): review fixups (security comment, least-privilege perms, robust timeouts)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,8 +8,12 @@ name: E2E Tests
 # BIFURCATION: unit tests (ci.yml) gate every PR. This e2e suite is slow and
 # runner-bound (self-hosted -- the maintainer's Bazzite box, labels `self-hosted,
 # linux`), so it does NOT run on pull requests at all: only on push to
-# develop/main (right before the beta/stable cuts) and on manual dispatch. No PR
-# trigger = no fork-PR vector: external contributors can never reach this runner.
+# develop/main (right before the beta/stable cuts) and on manual dispatch. With
+# no pull_request trigger, an UNREVIEWED fork PR can't fire this job -- but
+# merging a fork PR produces a push event, so merged external code (Dockerfile,
+# entrypoint, tests) DOES execute on this host. Review appiumtests/ infra
+# changes before merging, and prefer a dedicated unprivileged runner user so
+# merged/compromised code can't read ~/.ssh or the runner token.
 # (If you ever re-add `pull_request`, restore the fork `if:` gate below.)
 #
 # Runner registration (one-time, manual -- needs a repo token only you hold;
@@ -34,6 +38,9 @@ on:
   push:
     branches: [ develop, main ]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 # Single self-hosted runner + long image build: cancel a superseded run when a
 # new push lands on the same ref, instead of queuing behind it on one runner.
@@ -70,17 +77,17 @@ jobs:
           # UID into the namespace; --user makes the entrypoint actually run as
           # it. keep-id alone still launches as the image's default root, which
           # maps to a high host UID and CANNOT write the bind-mounted out/ dir
-          # (the exact EACCES that failed run #28906888526). This mirrors what
+          # (the EACCES seen on first CI run). This mirrors what
           # distrobox does locally. The entrypoint brings its own system bus,
           # mock helper, /tmp runtime, and software rendering -- no host
           # GPU/audio/device passthrough needed.
           # :Z relabels the bind mount to container_file_t -- mandatory under
           # SELinux (Enforcing), or the container process can't write the
-          # host-owned out/ dir (EACCES, runs #28906888526 + #28907384272).
+          # host-owned out/ dir (EACCES).
           # --cap-add all: kwin_wayland, sunshine, gstreamer helpers, etc. carry
           # file capabilities (cap_sys_nice, cap_sys_admin, ...). execve of a
           # file-cap'd binary returns EPERM in a rootless user namespace unless
-          # the cap is in the bounding set, so kwin exec failed (run #28907614634).
+          # the cap is in the bounding set, so kwin exec failed.
           # Adding all caps mirrors what distrobox does; safe here because the
           # container is rootless, isolated, and software-rendered (no host devs).
           # -e COUCHPLAY_E2E_LONG_TIMEOUT=120: the streaming test's "Start Session"

--- a/appiumtests/conftest.py
+++ b/appiumtests/conftest.py
@@ -33,7 +33,7 @@ def pytest_configure(config):
 SCREENSHOT_DIR = os.path.join(
     os.environ.get("APPIUM_ARTIFACT_OUTPUT_PATH") or os.path.dirname(__file__), "screenshots"
 )
-DEFAULT_TIMEOUT = int(os.environ.get("COUCHPLAY_E2E_TIMEOUT", "10"))
+DEFAULT_TIMEOUT = int(os.environ.get("COUCHPLAY_E2E_TIMEOUT") or "10")
 
 
 @pytest.fixture(scope="session")

--- a/appiumtests/test_session.py
+++ b/appiumtests/test_session.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.requires_helper
 
 # Env-overridable so CI (software-rendered, slower UI) can bump it without
 # touching test logic. Default is plenty for a local GPU-backed run.
-LONG_TIMEOUT = int(os.environ.get("COUCHPLAY_E2E_LONG_TIMEOUT", "20"))
+LONG_TIMEOUT = int(os.environ.get("COUCHPLAY_E2E_LONG_TIMEOUT") or "20")
 
 
 class TestSessionLifecycle(BaseTest):


### PR DESCRIPTION
## What
Addresses the code-review findings on #36 (the merged e2e-in-CI PR). No change to the green e2e execution path — these are comment accuracy, hardening, and edge-case robustness.

## Findings addressed

**MAJOR — security comment was false** (`.github/workflows/e2e.yml` header)
The bifurcation comment claimed *"external contributors can never reach this runner."* That's wrong: dropping `pull_request` only blocks **unreviewed** fork PRs from firing the job. A fork PR that's **merged** produces a `push` event, so the merged `appiumtests/` infra code (Dockerfile, entrypoint, tests) **does** execute on the host. Reworded to the accurate threat model, and the dedicated unprivileged runner user is now recommended (not framed as an optional extra).

**MINOR — least-privilege `permissions:`**
Added `permissions: { contents: read }`. The job issues no token writes (checkout=read, upload-artifact=none); scoping down the auto `GITHUB_TOKEN` is defense-in-depth on a public repo's self-hosted runner.

**MINOR — robust timeout env reads** (`conftest.py`, `test_session.py`)
`int(os.environ.get(X, default))` returned `""` (then raised `ValueError` at import → aborted pytest collection) when the var was **set-but-empty** (real risk: a `${{ }}` that expands empty, or `export X=`). Switched to the `or` idiom already used for `SCREENSHOT_DIR` in the same file. **Behavior-identical for CI's actual values** (`LONG_TIMEOUT=120` set; `TIMEOUT` unset → default 10).

**NIT — dropped run-number breadcrumbs**
Removed opaque Actions run IDs (`#28906888526` …) from comments — GC'd after ~90 days, non-linkable, convey nothing. Kept the symptom text (EACCES / kwin EPERM).

## Verification
- `py_compile` on both test files: OK.
- `e2e.yml` YAML validated: `permissions: {contents: read}`, triggers `[push, workflow_dispatch]` (no `pull_request`).
- No re-run needed: all four changes are behavior-neutral for CI's actual env values (proven equivalent for `LONG_TIMEOUT=120` / `TIMEOUT` unset); comment/permissions changes have zero runtime effect.

## Out of scope (deferred)
The review also flagged that the **AGENTS.md local-run command drifts from CI** (omits `COUCHPLAY_E2E_LONG_TIMEOUT=120` + `-p no:cacheprovider` the container needs under software rendering) — same root issue as the parked "coordinated cleanup" (move these into the shared `run-in-session.sh`). Not touched here per prior decision.