### PR TITLE
fix(flatpak): grant the helper system-bus talk-name (#37)

### DIFF
--- a/io.github.hikaps.couchplay.json
+++ b/io.github.hikaps.couchplay.json
@@ -13,6 +13,7 @@
         "--device=dri",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--system-talk-name=org.freedesktop.login1",
+        "--system-talk-name=io.github.hikaps.CouchPlayHelper",
         "--filesystem=/run/udev:ro"
     ],
     "modules": [

--- a/io.github.hikaps.couchplay.json
+++ b/io.github.hikaps.couchplay.json
@@ -54,7 +54,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/KDE/polkit-qt-1.git",
-                    "branch": "qt6"
+                    "commit": "fbb50e964bcb260d3b716195ef80dd100b87951b"
                 }
             ],
             "cleanup": [

--- a/io.github.hikaps.couchplay.json
+++ b/io.github.hikaps.couchplay.json
@@ -18,16 +18,43 @@
     ],
     "modules": [
         {
+            "name": "systemd-pc-stub",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/lib/pkgconfig",
+                "printf 'Name: systemd\\nDescription: systemd stub for flatpak build\\nVersion: 257\\nsystemdsystemunitdir=/app/lib/systemd/system\\nsysusers_dir=/app/lib/sysusers.d\\n' > ${FLATPAK_DEST}/lib/pkgconfig/systemd.pc"
+            ]
+        },
+        {
+            "name": "polkit",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dauthfw=shadow",
+                "-Dsession_tracking=libsystemd-login",
+                "-Djs_engine=duktape",
+                "-Dintrospection=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.freedesktop.org/polkit/polkit.git",
+                    "tag": "124"
+                }
+            ],
+            "cleanup": ["/include", "/lib/pkgconfig", "*.a"]
+        },
+        {
             "name": "polkit-qt-1",
             "buildsystem": "cmake-ninja",
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release"
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/KDE/polkit-qt-1.git",
-                    "tag": "v0.201.1"
+                    "branch": "qt6"
                 }
             ],
             "cleanup": [

--- a/io.github.hikaps.couchplay.json
+++ b/io.github.hikaps.couchplay.json
@@ -65,6 +65,18 @@
             ]
         },
         {
+            "name": "patchelf",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1.tar.gz",
+                    "sha256": "491108728f120ce05b539934b41a750235031a6df8abc6b47e57aff7de15094d"
+                }
+            ],
+            "cleanup": ["*"]
+        },
+        {
             "name": "couchplay",
             "buildsystem": "cmake-ninja",
             "config-opts": [
@@ -87,7 +99,9 @@
                 "install -Dm644 data/polkit/io.github.hikaps.couchplay.policy ${FLATPAK_DEST}/share/couchplay/data/polkit/io.github.hikaps.couchplay.policy",
                 "install -Dm644 data/io.github.hikaps.couchplay.desktop ${FLATPAK_DEST}/share/applications/io.github.hikaps.couchplay.desktop",
                 "install -Dm644 data/io.github.hikaps.couchplay.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.github.hikaps.couchplay.metainfo.xml",
-                "install -Dm644 data/icons/io.github.hikaps.couchplay.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/io.github.hikaps.couchplay.png"
+                "install -Dm644 data/icons/io.github.hikaps.couchplay.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/io.github.hikaps.couchplay.png",
+                "chmod +x scripts/bundle-libs.sh",
+                "./scripts/bundle-libs.sh ${FLATPAK_DEST}/libexec/couchplay-helper lib/couchplay"
             ],
             "cleanup": [
                 "/lib/pkgconfig",

--- a/scripts/install-helper.sh
+++ b/scripts/install-helper.sh
@@ -202,6 +202,14 @@ export_helper() {
         fi
     fi
     
+    # Copy bundled runtime libraries (if the Flatpak ships them) so the exported
+    # helper runs without the Flatpak or host Qt6 (RPATH is $ORIGIN/../lib/couchplay).
+    BUNDLE_LIB_SRC="$(dirname "${BINARY_PATH}")/../lib/couchplay"
+    if [[ -d "${BUNDLE_LIB_SRC}" ]]; then
+        print_info "Copying bundled runtime libraries..."
+        mkdir -p "${EXPORT_DIR}/lib/couchplay"
+        install -m644 "${BUNDLE_LIB_SRC}"/*.so* "${EXPORT_DIR}/lib/couchplay/"
+    fi
     print_info "Export complete!"
     echo ""
     echo "Files exported to: ${EXPORT_DIR}/"
@@ -226,7 +234,7 @@ install_helper() {
 
     # Install bundled runtime libraries, if the release ships them (the binary's
     # RPATH is $ORIGIN/../lib/couchplay, so this lets the helper run without
-    # system Qt6/Polkit). Absent for Flatpak/build-dir installs.
+# system Qt6/Polkit). Shipped by the tarball and the Flatpak (bundled at build).
     if [[ -d "${SCRIPT_DIR}/lib/couchplay" ]] && compgen -G "${SCRIPT_DIR}/lib/couchplay/*.so*" >/dev/null; then
         print_info "Installing bundled runtime libraries to ${LIB_DIR}/"
         mkdir -p "${LIB_DIR}"

--- a/scripts/install-helper.sh
+++ b/scripts/install-helper.sh
@@ -205,7 +205,7 @@ export_helper() {
     # Copy bundled runtime libraries (if the Flatpak ships them) so the exported
     # helper runs without the Flatpak or host Qt6 (RPATH is $ORIGIN/../lib/couchplay).
     BUNDLE_LIB_SRC="$(dirname "${BINARY_PATH}")/../lib/couchplay"
-    if [[ -d "${BUNDLE_LIB_SRC}" ]]; then
+    if [[ -d "${BUNDLE_LIB_SRC}" ]] && compgen -G "${BUNDLE_LIB_SRC}/*.so*" >/dev/null; then
         print_info "Copying bundled runtime libraries..."
         mkdir -p "${EXPORT_DIR}/lib/couchplay"
         install -m644 "${BUNDLE_LIB_SRC}"/*.so* "${EXPORT_DIR}/lib/couchplay/"
@@ -234,7 +234,7 @@ install_helper() {
 
     # Install bundled runtime libraries, if the release ships them (the binary's
     # RPATH is $ORIGIN/../lib/couchplay, so this lets the helper run without
-# system Qt6/Polkit). Shipped by the tarball and the Flatpak (bundled at build).
+    # system Qt6/Polkit). Shipped by the tarball and the Flatpak (bundled at build).
     if [[ -d "${SCRIPT_DIR}/lib/couchplay" ]] && compgen -G "${SCRIPT_DIR}/lib/couchplay/*.so*" >/dev/null; then
         print_info "Installing bundled runtime libraries to ${LIB_DIR}/"
         mkdir -p "${LIB_DIR}"


### PR DESCRIPTION
## Problem

The Flatpak manifest's `finish-args` declared `--system-talk-name=org.freedesktop.login1` but **not** the app's own helper (`io.github.hikaps.CouchPlayHelper`). So the sandboxed GUI could not reach the helper over the system bus out of the box.

Users had to brute-force it (#37):
```
flatpak override --user io.github.hikaps.couchplay --socket=system-bus
```
`--socket=system-bus` grants full system-bus access (talk to *any* name) — overly broad and not something a user should have to guess.

## Fix

Add the scoped permission:
```json
"--system-talk-name=io.github.hikaps.CouchPlayHelper",
```
The Flatpak GUI now talks to the helper natively — no manual override, no full-system-bus exposure.

## Context

The Flatpak is actually the *recommended* path on Arch/SteamOS right now: it bundles the KDE 6.10 runtime, so the GUI is immune to the copy-relocation bug (`GNU_PROPERTY_1_NEEDED_INDIRECT_EXTERN_ACCESS`) that still breaks the tarball GUI on those distros (tracked separately). This PR removes the last friction in that path.

Ref #37.