### PR TITLE
ci(flatpak): auto-build a beta Flatpak on develop push (#37)

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -2,6 +2,7 @@ name: Flatpak Build
 
 on:
   push:
+    branches: [ develop ]
     tags:
       - 'v*'
   workflow_dispatch:
@@ -25,6 +26,11 @@ jobs:
             echo "::error::Tag ${{ github.ref_name }} is not on main branch. Releases must be tagged from main."
             exit 1
           fi
+
+      - name: Build app from develop for beta
+        if: github.ref == 'refs/heads/develop'
+        run: |
+          sed -i 's|"branch": "main"|"branch": "develop"|' io.github.hikaps.couchplay.json
 
       - name: Install flatpak-builder
         run: |
@@ -58,6 +64,14 @@ jobs:
         with:
           name: flatpak-bundle
           path: couchplay.flatpak
+
+      - name: Publish Flatpak to beta release
+        if: github.ref == 'refs/heads/develop'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: beta
+          prerelease: true
+          files: couchplay.flatpak
 
       - name: Upload to Release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Problem

`flatpak.yml` only builds on `v*` tags (or manual dispatch), so the Flatpak fix from #40 — now on `develop` — isn't publishable until a release cut. This is asymmetric with the **beta tarball** (`beta.yml`), which auto-builds on every develop push. So Arch/SteamOS users (#28/#37) have no installable Flatpak today.

## Change

Mirror `beta.yml` for the Flatpak:
- **Trigger** on `push: branches: [develop]` (in addition to tags).
- On a develop build, **point the manifest's app source at `develop`** (`sed` `main` → `develop`) — because the manifest builds `main`, which lacks `scripts/bundle-libs.sh` + the `install-helper.sh` change until the next `develop → main`. Tag/stable builds keep `main`.
- **Publish** `couchplay.flatpak` to the `beta` release (prerelease) on develop push.

## Result

Merging a Flatpak fix to `develop` now ships an **installable beta Flatpak automatically** — same cadence as the beta tarball. In fact, **merging this PR triggers the first beta Flatpak build** (it's a develop push).

The beta Flatpak will bundle the KDE/Qt runtime (GUI works on Arch/SteamOS) + the bundled helper, so it's the single-install path for those distros.

## Note
`beta.yml` (tarball) and this both publish to the `beta` release on develop push; asset filenames differ (`couchplay-x86_64.tar.xz` vs `couchplay.flatpak`), so they coexist. The release metadata is owned by `beta.yml`; this only adds the Flatpak asset.