### PR TITLE
fix(flatpak): force polkit libdir=lib (CI picked lib64) (#37)

### DIFF
--- a/io.github.hikaps.couchplay.json
+++ b/io.github.hikaps.couchplay.json
@@ -29,6 +29,7 @@
             "name": "polkit",
             "buildsystem": "meson",
             "config-opts": [
+                "-Dlibdir=lib",
                 "-Dauthfw=shadow",
                 "-Dsession_tracking=libsystemd-login",
                 "-Djs_engine=duktape",


### PR DESCRIPTION
## Problem

The first beta Flatpak build (run #29052411723) failed: in CI, meson chose `libdir=lib64` for polkit, so `polkit-gobject-1.pc` landed in `/app/lib64/pkgconfig` — **not** in the flatpak build's `PKG_CONFIG_PATH` — and `polkit-qt-1` couldn't find it. Locally meson picked a searched libdir, masking the issue.

## Fix

Add `-Dlibdir=lib` to the polkit module's meson config-opts → forces `/app/lib/pkgconfig` (always searched), so the pkgconfig is found consistently across environments. One-line change; builds on #40.