### PR TITLE
fix(flatpak): route host user identity through the helper (#37)

### DIFF
--- a/appiumtests/helpers/mock_helper.py
+++ b/appiumtests/helpers/mock_helper.py
@@ -19,6 +19,8 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+import grp
+import pwd
 
 import dbus
 import dbus.service
@@ -219,6 +221,55 @@ class MockHelper(dbus.service.Object):
     @dbus.service.method(INTERFACE_NAME, in_signature="s", out_signature="s")
     def GetUserSteamId(self, username):
         return ""
+
+    @dbus.service.method(INTERFACE_NAME, in_signature="", out_signature="as")
+    def ListCouchPlayUsers(self):
+        entries = []
+        for username in self._couchplayUsernames():
+            fields = self._userFields(username)
+            if fields is None:
+                continue
+            name, uid, gid, home, shell = fields
+            if uid < 1000 or uid >= 65534:
+                continue
+            if "nologin" in shell or "false" in shell:
+                continue
+            if not os.path.isdir(home):
+                continue
+            entries.append("%s\t%d\t%d\t%s\t%s" % (name, uid, gid, home, shell))
+        return dbus.Array(entries, signature="s")
+
+    @dbus.service.method(INTERFACE_NAME, in_signature="s", out_signature="a{sv}")
+    def GetUserInfo(self, username):
+        fields = self._userFields(username)
+        if fields is None:
+            return dbus.Dictionary({}, signature="sv")
+        name, uid, gid, home, shell = fields
+        return dbus.Dictionary({
+            "uid": dbus.UInt32(uid),
+            "gid": dbus.UInt32(gid),
+            "home": home,
+        }, signature="sv")
+
+    def _couchplayUsernames(self):
+        if FAKE_USERS:
+            return list(self._created_users.keys())
+        try:
+            return list(grp.getgrnam("couchplay").gr_mem)
+        except KeyError:
+            return []
+
+    def _userFields(self, username):
+        if FAKE_USERS:
+            uid = self._created_users.get(username)
+            if uid is None:
+                return None
+            return (username, uid, uid, "/home/%s" % username, "/bin/bash")
+        try:
+            p = pwd.getpwnam(username)
+        except KeyError:
+            return None
+        return (p.pw_name, p.pw_uid, p.pw_gid, p.pw_dir, p.pw_shell)
 
     @dbus.service.method(INTERFACE_NAME, in_signature="ayss", out_signature="b")
     def WriteFileToUser(self, content, targetPath, username):

--- a/helper/CouchPlayHelper.cpp
+++ b/helper/CouchPlayHelper.cpp
@@ -469,6 +469,68 @@ bool CouchPlayHelper::IsInCouchPlayGroup(const QString &username)
     return false;
 }
 
+QStringList CouchPlayHelper::ListCouchPlayUsers()
+{
+    QStringList result;
+
+    struct group *grp = m_ops->getgrnam(COUCHPLAY_GROUP.toLocal8Bit().constData());
+    if (!grp) {
+        return result; // Group doesn't exist yet
+    }
+
+    for (char **member = grp->gr_mem; *member != nullptr; ++member) {
+        const QString username = QString::fromLocal8Bit(*member);
+        struct passwd *pw = m_ops->getpwnam(username.toLocal8Bit().constData());
+        if (!pw) {
+            continue;
+        }
+
+        // Copy fields immediately: passwd* is only valid until the next getpwnam call.
+        const uint uid = pw->pw_uid;
+        const uint gid = pw->pw_gid;
+        const QString home = QString::fromLocal8Bit(pw->pw_dir);
+        const QString shell = QString::fromLocal8Bit(pw->pw_shell);
+
+        // Filters matching UserManager::parseUsers (src/core/UserManager.cpp)
+        if (uid < 1000 || uid >= 65534) {
+            continue;
+        }
+        if (shell.contains(QStringLiteral("nologin")) || shell.contains(QStringLiteral("false"))) {
+            continue;
+        }
+        if (!m_ops->fileExists(home)) {
+            continue;
+        }
+
+        result.append(QStringLiteral("%1\t%2\t%3\t%4\t%5")
+                          .arg(username)
+                          .arg(uid)
+                          .arg(gid)
+                          .arg(home, shell));
+    }
+
+    return result;
+}
+
+QVariantMap CouchPlayHelper::GetUserInfo(const QString &username)
+{
+    QVariantMap info;
+    if (!s_validUsername.match(username).hasMatch()) {
+        sendErrorReply(QDBusError::InvalidArgs, QStringLiteral("Invalid username format"));
+        return info;
+    }
+
+    struct passwd *pw = m_ops->getpwnam(username.toLocal8Bit().constData());
+    if (!pw) {
+        return info;
+    }
+
+    info.insert(QStringLiteral("uid"), static_cast<uint>(pw->pw_uid));
+    info.insert(QStringLiteral("gid"), static_cast<uint>(pw->pw_gid));
+    info.insert(QStringLiteral("home"), QString::fromLocal8Bit(pw->pw_dir));
+    return info;
+}
+
 bool CouchPlayHelper::DeleteUser(const QString &username, bool removeHome)
 {
     if (!validateUserAndAuth(username, ACTION_DELETE_USER)) {

--- a/helper/CouchPlayHelper.h
+++ b/helper/CouchPlayHelper.h
@@ -68,6 +68,22 @@ public Q_SLOTS:
      * @return true if user is in couchplay group
      */
     bool IsInCouchPlayGroup(const QString &username);
+    /**
+     * List all CouchPlay-managed users (couchplay group members).
+     * Read-only — no polkit. Each entry is tab-delimited: username\tuid\tgid\thome\tshell.
+     *
+     * @return list of user entries (filtered: uid 1000-65533, valid shell, home exists)
+     */
+    QStringList ListCouchPlayUsers();
+
+    /**
+     * Get uid/gid/home for a named user.
+     * Read-only — no polkit.
+     *
+     * @param username Username to look up
+     * @return map with keys "uid","gid","home", or empty if not found/invalid
+     */
+    QVariantMap GetUserInfo(const QString &username);
 
     /**
      * Enable systemd linger for a user

--- a/io.github.hikaps.couchplay.json
+++ b/io.github.hikaps.couchplay.json
@@ -11,6 +11,7 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=dri",
+        "--device=input",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--system-talk-name=org.freedesktop.login1",
         "--system-talk-name=io.github.hikaps.CouchPlayHelper",

--- a/scripts/install-helper.sh
+++ b/scripts/install-helper.sh
@@ -86,6 +86,10 @@ if [[ -f "/app/libexec/${HELPER_BINARY}" ]]; then
     FLATPAK_LIBEXEC="/app/libexec"
     BINARY_PATH="${FLATPAK_LIBEXEC}/${HELPER_BINARY}"
     DATA_DIR="/app/share/couchplay/data"
+elif [[ -f "${SCRIPT_DIR}/${HELPER_BINARY}" ]]; then
+    # Flatpak-export layout: helper exported to a host dir (binary at root)
+    BINARY_PATH="${SCRIPT_DIR}/${HELPER_BINARY}"
+    DATA_DIR="${SCRIPT_DIR}/data"
 elif [[ -f "${SCRIPT_DIR}/bin/${HELPER_BINARY}" ]]; then
     # Release tarball structure
     RELEASE_DIR="${SCRIPT_DIR}"
@@ -260,12 +264,15 @@ install_helper() {
     install -Dm644 "${DATA_DIR}/polkit/io.github.hikaps.couchplay.policy" \
         "${POLKIT_DIR}/io.github.hikaps.couchplay.policy"
 
-    # Install PipeWire PulseAudio TCP listener config
-    print_info "Installing PipeWire PulseAudio TCP listener..."
     SYSTEM_PIPEWIRE_PULSE_CONF_DIR="${PREFIX}/share/pipewire/pipewire-pulse.conf.d"
-    mkdir -p "$SYSTEM_PIPEWIRE_PULSE_CONF_DIR"
-    install -Dm644 "${DATA_DIR}/pipewire/50-couchplay.conf" \
-        "${SYSTEM_PIPEWIRE_PULSE_CONF_DIR}/50-couchplay.conf"
+    if [[ -f "${DATA_DIR}/pipewire/50-couchplay.conf" ]]; then
+        print_info "Installing PipeWire PulseAudio TCP listener..."
+        mkdir -p "$SYSTEM_PIPEWIRE_PULSE_CONF_DIR"
+        install -Dm644 "${DATA_DIR}/pipewire/50-couchplay.conf" \
+            "${SYSTEM_PIPEWIRE_PULSE_CONF_DIR}/50-couchplay.conf"
+    else
+        print_warn "PipeWire config not in export — skipping (optional; affects streaming audio only)."
+    fi
 
     # Reload systemd
     print_info "Reloading systemd..."

--- a/src/core/HeroicConfigManager.cpp
+++ b/src/core/HeroicConfigManager.cpp
@@ -4,6 +4,7 @@
 #include "HeroicConfigManager.h"
 #include "../dbus/CouchPlayHelperClient.h"
 #include "Logging.h"
+#include "UserLookup.h"
 
 #include <QDebug>
 #include <QDir>
@@ -223,13 +224,13 @@ bool HeroicConfigManager::syncShortcutsToUser(const QString &targetUsername)
         return true;
     }
 
-    struct passwd *pw = getpwnam(targetUsername.toLocal8Bit().constData());
-    if (!pw) {
+    const UserIdentity id = resolveUserIdentity(targetUsername, m_helperClient);
+    if (!id.valid) {
         qWarning() << "HeroicConfigManager: User not found:" << targetUsername;
         Q_EMIT syncFailed(targetUsername, QStringLiteral("User not found"));
         return false;
     }
-    QString targetHome = QString::fromLocal8Bit(pw->pw_dir);
+    QString targetHome = id.home;
     QString targetDir = targetHome + QStringLiteral("/.local/share/applications");
 
     if (!targetDir.startsWith(targetHome + QLatin1Char('/'))) {
@@ -280,12 +281,12 @@ bool HeroicConfigManager::syncConfigToUser(const QString &targetUsername)
         return false;
     }
 
-    struct passwd *pw = getpwnam(targetUsername.toLocal8Bit().constData());
-    if (!pw) {
+    const UserIdentity id = resolveUserIdentity(targetUsername, m_helperClient);
+    if (!id.valid) {
         qWarning() << "HeroicConfigManager: User not found:" << targetUsername;
         return false;
     }
-    QString targetHome = QString::fromLocal8Bit(pw->pw_dir);
+    QString targetHome = id.home;
 
     QString targetHeroicRoot;
     if (m_heroicPaths.isFlatpak) {

--- a/src/core/SessionRunner.cpp
+++ b/src/core/SessionRunner.cpp
@@ -11,6 +11,7 @@
 #include "SettingsManager.h"
 #include "SteamConfigManager.h"
 #include "StreamManager.h"
+#include "UserLookup.h"
 #include "WindowManager.h"
 
 #include <QAction>
@@ -75,6 +76,7 @@ SessionRunner::SessionRunner(QObject *parent)
     connect(m_windowManager, &WindowManager::positioningTimedOut, this, &SessionRunner::onWindowPositioningTimeout);
 
     m_streamManager = new StreamManager(this);
+    m_streamManager->setHelperClient(m_helperClient);
     connect(m_streamManager, &StreamManager::streamError,
             this, [this](int instanceIndex, const QString &error) {
         Q_EMIT errorOccurred(QStringLiteral("Stream %1: %2").arg(instanceIndex).arg(error));
@@ -124,6 +126,9 @@ void SessionRunner::setHelperClient(CouchPlayHelperClient *client)
 {
     if (m_helperClient != client) {
         m_helperClient = client;
+        if (m_streamManager) {
+            m_streamManager->setHelperClient(client);
+        }
         Q_EMIT helperClientChanged();
     }
 }
@@ -201,8 +206,11 @@ bool SessionRunner::start()
         }
     }
 
-    struct passwd *compositorPw = getpwuid(getuid());
-    QString compositorUser = compositorPw ? QString::fromLocal8Bit(compositorPw->pw_name) : QString();
+    QString compositorUser = qEnvironmentVariable("USER");
+    if (compositorUser.isEmpty()) {
+        struct passwd *compositorPw = getpwuid(getuid());
+        compositorUser = compositorPw ? QString::fromLocal8Bit(compositorPw->pw_name) : QString();
+    }
 
     for (int i = 0; i < instanceCount; ++i) {
         const QString &username = profile.instances[i].username;
@@ -213,7 +221,10 @@ bool SessionRunner::start()
         if (username == compositorUser) {
             continue;
         }
-        if (!isUserInCouchPlayGroup(username)) {
+        const bool inGroup = (m_helperClient && m_helperClient->isAvailable())
+                                 ? m_helperClient->isInCouchPlayGroup(username)
+                                 : isUserInCouchPlayGroup(username);
+        if (!inGroup) {
             Q_EMIT errorOccurred(QStringLiteral("User '%1' is not a CouchPlay managed user. Please create the user via "
                                                 "CouchPlay or add them to the 'couchplay' group.")
                                      .arg(username));
@@ -589,12 +600,12 @@ bool SessionRunner::setupDeviceOwnership()
             continue;
         }
 
-        struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
-        if (!pw) {
+        const UserIdentity id = resolveUserIdentity(username, m_helperClient);
+        if (!id.valid) {
             qWarning() << "SessionRunner: User" << username << "not found, skipping device ownership for instance" << i;
             continue;
         }
-        int uid = static_cast<int>(pw->pw_uid);
+        int uid = static_cast<int>(id.uid);
 
         QStringList devicePaths = m_deviceManager->getDevicePathsForInstance(i);
 
@@ -1194,12 +1205,12 @@ void SessionRunner::onDeviceReconnected(const QString &stableId, int eventNumber
         return;
     }
 
-    struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
-    if (!pw) {
+    const UserIdentity id = resolveUserIdentity(username, m_helperClient);
+    if (!id.valid) {
         qWarning() << "SessionRunner: User" << username << "not found";
         return;
     }
-    int uid = static_cast<int>(pw->pw_uid);
+    int uid = static_cast<int>(id.uid);
 
     QString devicePath = QStringLiteral("/dev/input/event%1").arg(eventNumber);
 
@@ -1384,13 +1395,13 @@ void SessionRunner::onVirtualDeviceAppeared(int eventNumber, const QString &devi
         return;
     }
 
-    struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
-    if (!pw) {
+    const UserIdentity id = resolveUserIdentity(username, m_helperClient);
+    if (!id.valid) {
         qWarning() << "SessionRunner: User" << username << "not found";
         return;
     }
 
-    if (m_helperClient->setDeviceOwner(devicePath, pw->pw_uid)) {
+    if (m_helperClient->setDeviceOwner(devicePath, id.uid)) {
         if (!m_ownedDevicePaths.contains(devicePath)) {
             m_ownedDevicePaths.append(devicePath);
         }

--- a/src/core/SteamConfigManager.cpp
+++ b/src/core/SteamConfigManager.cpp
@@ -4,6 +4,7 @@
 #include "SteamConfigManager.h"
 #include "../dbus/CouchPlayHelperClient.h"
 #include "Logging.h"
+#include "UserLookup.h"
 
 #include <QDataStream>
 #include <QDebug>
@@ -158,13 +159,13 @@ QString SteamConfigManager::getTargetSteamUserId(const QString &username) const
     // Fallback: try to read directly (will only work for current user)
     qDebug() << "SteamConfigManager: Helper not available, trying direct access for" << username;
 
-    struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
-    if (!pw) {
+    const UserIdentity id = resolveUserIdentity(username, m_helperClient);
+    if (!id.valid) {
         qWarning() << "SteamConfigManager: User not found:" << username;
         return QString();
     }
 
-    QString targetHome = QString::fromLocal8Bit(pw->pw_dir);
+    QString targetHome = id.home;
 
     // Check for Steam userdata in common locations
     QStringList possibleRoots = {
@@ -331,13 +332,13 @@ bool SteamConfigManager::syncShortcutsToUser(const QString &targetUsername)
     qCDebug(couchplaySteam) << "Target Steam ID:" << targetSteamId;
 
     // Get target user's home
-    struct passwd *pw = getpwnam(targetUsername.toLocal8Bit().constData());
-    if (!pw) {
+    const UserIdentity id = resolveUserIdentity(targetUsername, m_helperClient);
+    if (!id.valid) {
         qCWarning(couchplaySteam) << "syncShortcutsToUser failed - User not found:" << targetUsername;
         Q_EMIT syncFailed(targetUsername, QStringLiteral("User not found"));
         return false;
     }
-    QString targetHome = QString::fromLocal8Bit(pw->pw_dir);
+    QString targetHome = id.home;
     qCDebug(couchplaySteam) << "Target home:" << targetHome;
 
     // Target path uses TARGET user's Steam ID (not compositor's)
@@ -403,13 +404,13 @@ SteamPaths SteamConfigManager::getTargetSteamPaths(const QString &username) cons
     SteamPaths paths;
 
     // Get target user's home directory
-    struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
-    if (!pw) {
+    const UserIdentity id = resolveUserIdentity(username, m_helperClient);
+    if (!id.valid) {
         qWarning() << "SteamConfigManager: User not found:" << username;
         return paths;
     }
 
-    QString targetHome = QString::fromLocal8Bit(pw->pw_dir);
+    QString targetHome = id.home;
 
     // Check for Steam in common locations relative to target home
     QStringList possibleRoots = {
@@ -864,12 +865,12 @@ bool SteamConfigManager::shareLibraryToUser(const QString &targetUsername)
         return false;
     }
     
-    struct passwd *pw = getpwnam(targetUsername.toLocal8Bit().constData());
-    if (!pw) {
+    const UserIdentity id = resolveUserIdentity(targetUsername, m_helperClient);
+    if (!id.valid) {
         qCWarning(couchplaySteam) << "shareLibraryToUser failed - User not found:" << targetUsername;
         return false;
     }
-    QString targetHome = QString::fromLocal8Bit(pw->pw_dir);
+    QString targetHome = id.home;
     
     QString targetSteamId = getTargetSteamUserId(targetUsername);
     if (targetSteamId.isEmpty()) {

--- a/src/core/StreamManager.cpp
+++ b/src/core/StreamManager.cpp
@@ -4,6 +4,7 @@
 #include "StreamManager.h"
 
 #include "SunshineConfig.h"
+#include "UserLookup.h"
 
 #include <QDBusConnection>
 #include <QDBusInterface>
@@ -26,12 +27,10 @@ static constexpr int RESTART_DELAY_MS = 2000;
 // output, which the helper runs as the streaming user -- so its Wayland socket
 // lives in /run/user/<streamingUserUid>, NOT the GUI user's runtime dir. Resolve
 // the streaming user's uid; fall back to the GUI uid only if the lookup fails.
-static uid_t resolveCompositorUid(const QString &username)
+uid_t StreamManager::resolveCompositorUid(const QString &username) const
 {
-    if (const passwd *pwd = getpwnam(username.toLocal8Bit().constData())) {
-        return pwd->pw_uid;
-    }
-    return ::getuid();
+    const UserIdentity id = resolveUserIdentity(username, m_helperClient);
+    return id.valid ? static_cast<uid_t>(id.uid) : ::getuid();
 }
 
 StreamManager::StreamManager(QObject *parent)

--- a/src/core/StreamManager.h
+++ b/src/core/StreamManager.h
@@ -11,8 +11,11 @@
 #include <QTimer>
 #include <QPointer>
 #include <qqmlintegration.h>
+#include <sys/types.h>
 
 struct InstanceConfig;
+
+class CouchPlayHelperClient;
 
 /**
  * @brief Manages Sunshine streaming subprocesses per player instance
@@ -55,6 +58,7 @@ public:
 
     StreamState streamState(int instanceIndex) const;
     bool isStreaming(int instanceIndex) const;
+    void setHelperClient(CouchPlayHelperClient *helper) { m_helperClient = helper; }
 
 Q_SIGNALS:
     void streamStarted(int instanceIndex);
@@ -72,6 +76,9 @@ private:
     void setStreamState(int instanceIndex, StreamState state);
     void cleanupConfigDir(int instanceIndex);
     void attemptRestart(int instanceIndex);
+    uid_t resolveCompositorUid(const QString &username) const;
+
+    CouchPlayHelperClient *m_helperClient = nullptr;
 
     struct StreamEntry {
         StreamState state = NotStarted;

--- a/src/core/UserLookup.h
+++ b/src/core/UserLookup.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 CouchPlay Contributors
+
+#pragma once
+
+#include "../dbus/CouchPlayHelperClient.h"
+
+#include <pwd.h>
+#include <unistd.h>
+
+#include <QString>
+#include <QVariantMap>
+
+struct UserIdentity {
+    bool valid = false;
+    uint uid = 0;
+    uint gid = 0;
+    QString home;
+};
+
+inline UserIdentity resolveUserIdentity(const QString &username, CouchPlayHelperClient *helper)
+{
+    UserIdentity id;
+
+    if (helper && helper->isAvailable()) {
+        const QVariantMap m = helper->getUserInfo(username);
+        if (!m.isEmpty()) {
+            id.valid = true;
+            id.uid = m.value(QStringLiteral("uid")).toUInt();
+            id.gid = m.value(QStringLiteral("gid")).toUInt();
+            id.home = m.value(QStringLiteral("home")).toString();
+        }
+        return id;
+    }
+
+    if (struct passwd *pw = getpwnam(username.toLocal8Bit().constData())) {
+        id.valid = true;
+        id.uid = pw->pw_uid;
+        id.gid = pw->pw_gid;
+        id.home = QString::fromLocal8Bit(pw->pw_dir);
+    }
+
+    return id;
+}

--- a/src/core/UserManager.cpp
+++ b/src/core/UserManager.cpp
@@ -20,10 +20,12 @@ static const QString COUCHPLAY_GROUP = QStringLiteral("couchplay");
 UserManager::UserManager(QObject *parent)
     : QObject(parent)
 {
-    // Get current user
-    struct passwd *pw = getpwuid(getuid());
-    if (pw) {
-        m_currentUser = QString::fromLocal8Bit(pw->pw_name);
+    m_currentUser = qEnvironmentVariable("USER");
+    if (m_currentUser.isEmpty()) {
+        struct passwd *pw = getpwuid(getuid());
+        if (pw) {
+            m_currentUser = QString::fromLocal8Bit(pw->pw_name);
+        }
     }
 
     refresh();
@@ -84,6 +86,18 @@ QSet<QString> UserManager::getCouchPlayGroupMembers() const
 
 void UserManager::parseUsers()
 {
+    if (m_helperClient && m_helperClient->isAvailable()) {
+        const QStringList entries = m_helperClient->listCouchPlayUsers();
+        for (const QString &entry : entries) {
+            const QStringList fields = entry.split(QLatin1Char('\t'));
+            // Format: username\tuid\tgid\thome\tshell
+            if (fields.size() < 5 || fields[0] == m_currentUser) {
+                continue;
+            }
+            m_users.append({fields[0], fields[1].toInt(), fields[3], fields[4]});
+        }
+        return;
+    }
     // Get couchplay group members
     QSet<QString> couchplayMembers = getCouchPlayGroupMembers();
 
@@ -239,7 +253,9 @@ bool UserManager::isValidUsername(const QString &username) const
 
 bool UserManager::userExists(const QString &username) const
 {
-    // Check getpwnam for any user
+    if (m_helperClient && m_helperClient->isAvailable()) {
+        return !m_helperClient->getUserInfo(username).isEmpty();
+    }
     struct passwd *pw = getpwnam(username.toLocal8Bit().constData());
     return pw != nullptr;
 }

--- a/src/dbus/CouchPlayHelperClient.cpp
+++ b/src/dbus/CouchPlayHelperClient.cpp
@@ -151,6 +151,38 @@ bool CouchPlayHelperClient::isInCouchPlayGroup(const QString &username)
     return reply.value();
 }
 
+QStringList CouchPlayHelperClient::listCouchPlayUsers()
+{
+    if (!m_available) {
+        return {};
+    }
+
+    QDBusReply<QStringList> reply = m_interface->call(QStringLiteral("ListCouchPlayUsers"));
+
+    if (!reply.isValid()) {
+        Q_EMIT errorOccurred(reply.error().message());
+        return {};
+    }
+
+    return reply.value();
+}
+
+QVariantMap CouchPlayHelperClient::getUserInfo(const QString &username)
+{
+    if (!m_available) {
+        return {};
+    }
+
+    QDBusReply<QVariantMap> reply = m_interface->call(QStringLiteral("GetUserInfo"), username);
+
+    if (!reply.isValid()) {
+        Q_EMIT errorOccurred(reply.error().message());
+        return {};
+    }
+
+    return reply.value();
+}
+
 qint64 CouchPlayHelperClient::launchInstance(const QString &username,
                                              uint compositorUid,
                                              const QStringList &gamescopeArgs,

--- a/src/dbus/CouchPlayHelperClient.h
+++ b/src/dbus/CouchPlayHelperClient.h
@@ -8,6 +8,7 @@
 #include <qqmlintegration.h>
 #include <QString>
 #include <QStringList>
+#include <QVariantMap>
 
 /**
  * @brief D-Bus client for the privileged CouchPlay helper
@@ -27,7 +28,7 @@ public:
         return m_available;
     }
 
-    Q_INVOKABLE bool setDeviceOwner(const QString &devicePath, int uid);
+    Q_INVOKABLE virtual bool setDeviceOwner(const QString &devicePath, int uid);
 
     /**
      * @brief Restore device ownership to root:input
@@ -48,7 +49,18 @@ public:
      */
     Q_INVOKABLE bool deleteUser(const QString &username, bool removeHome);
 
-    Q_INVOKABLE bool isInCouchPlayGroup(const QString &username);
+    Q_INVOKABLE virtual bool isInCouchPlayGroup(const QString &username);
+
+    /**
+     * @brief List CouchPlay-managed users (tab-delimited: username\tuid\tgid\thome\tshell)
+     */
+    Q_INVOKABLE virtual QStringList listCouchPlayUsers();
+
+    /**
+     * @brief Resolve uid/gid/home for a named user via the helper
+     * @return map with keys "uid","gid","home", or empty if unavailable/not found
+     */
+    Q_INVOKABLE virtual QVariantMap getUserInfo(const QString &username);
 
     /**
      * @brief Launch a gamescope instance as a specified user

--- a/tests/test_couchplayhelper.cpp
+++ b/tests/test_couchplayhelper.cpp
@@ -370,6 +370,10 @@ private Q_SLOTS:
     void testEnableLingerProcessFailure();
     void testIsLingerEnabledTrue();
     void testIsLingerEnabledFalse();
+    void testListCouchPlayUsers();
+    void testListCouchPlayUsersFilters();
+    void testGetUserInfo();
+    void testGetUserInfoNotFound();
 
     // Device ownership tests
     void testChangeDeviceOwnerInvalidPathNotUnderDevInput();
@@ -1532,6 +1536,64 @@ void TestCouchPlayHelper::testLaunchInstance_staleUnitRecovery()
     QVERIFY2(foundResetFailed, "systemctl reset-failed should be called during stale unit recovery");
     QVERIFY2(systemdRunCount >= 2, "systemd-run should be called at least twice (initial + retry)");
     QVERIFY2(foundEnvEFlag, "-E flag should be used for environment variables");
+}
+
+void TestCouchPlayHelper::testListCouchPlayUsers()
+{
+    m_ops->clear();
+    m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001,
+                          {QStringLiteral("player1"), QStringLiteral("player2")});
+    m_ops->setUserExists(QStringLiteral("player1"), true, 1001, 1001, QStringLiteral("/home/player1"));
+    m_ops->setUserExists(QStringLiteral("player2"), true, 1002, 1001, QStringLiteral("/home/player2"));
+    m_ops->setFileExists(QStringLiteral("/home/player1"), true);
+    m_ops->setFileExists(QStringLiteral("/home/player2"), true);
+
+    QDBusReply<QStringList> reply = m_dbusInterface->call(QStringLiteral("ListCouchPlayUsers"));
+
+    QVERIFY(reply.isValid());
+    const QStringList users = reply.value();
+    QCOMPARE(users.size(), 2);
+    QVERIFY(users.contains(QStringLiteral("player1\t1001\t1001\t/home/player1\t/bin/bash")));
+    QVERIFY(users.contains(QStringLiteral("player2\t1002\t1001\t/home/player2\t/bin/bash")));
+}
+
+void TestCouchPlayHelper::testListCouchPlayUsersFilters()
+{
+    m_ops->clear();
+    m_ops->setGroupExists(QStringLiteral("couchplay"), true, 1001,
+                          {QStringLiteral("lowuid"), QStringLiteral("nohome")});
+    m_ops->setUserExists(QStringLiteral("lowuid"), true, 999, 1001, QStringLiteral("/home/lowuid"));
+    m_ops->setFileExists(QStringLiteral("/home/lowuid"), true);
+    m_ops->setUserExists(QStringLiteral("nohome"), true, 1003, 1001, QStringLiteral("/home/nohome"));
+
+    QDBusReply<QStringList> reply = m_dbusInterface->call(QStringLiteral("ListCouchPlayUsers"));
+
+    QVERIFY(reply.isValid());
+    QVERIFY(reply.value().isEmpty());
+}
+
+void TestCouchPlayHelper::testGetUserInfo()
+{
+    m_ops->clear();
+    m_ops->setUserExists(QStringLiteral("player1"), true, 1001, 1001, QStringLiteral("/home/player1"));
+
+    QDBusReply<QVariantMap> reply = m_dbusInterface->call(QStringLiteral("GetUserInfo"), QStringLiteral("player1"));
+
+    QVERIFY(reply.isValid());
+    const QVariantMap info = reply.value();
+    QCOMPARE(info.value(QStringLiteral("uid")).toUInt(), 1001u);
+    QCOMPARE(info.value(QStringLiteral("gid")).toUInt(), 1001u);
+    QCOMPARE(info.value(QStringLiteral("home")).toString(), QStringLiteral("/home/player1"));
+}
+
+void TestCouchPlayHelper::testGetUserInfoNotFound()
+{
+    m_ops->clear();
+
+    QDBusReply<QVariantMap> reply = m_dbusInterface->call(QStringLiteral("GetUserInfo"), QStringLiteral("ghost"));
+
+    QVERIFY(reply.isValid());
+    QVERIFY(reply.value().isEmpty());
 }
 
 QTEST_MAIN(TestCouchPlayHelper)

--- a/tests/test_heroicconfigmanager.cpp
+++ b/tests/test_heroicconfigmanager.cpp
@@ -40,6 +40,17 @@ public:
         return QFile::copy(sourcePath, targetPath);
     }
 
+    QVariantMap getUserInfo(const QString &username) override
+    {
+        QVariantMap info;
+        if (const struct passwd *pw = getpwnam(username.toLocal8Bit().constData())) {
+            info.insert(QStringLiteral("uid"), static_cast<uint>(pw->pw_uid));
+            info.insert(QStringLiteral("gid"), static_cast<uint>(pw->pw_gid));
+            info.insert(QStringLiteral("home"), QString::fromLocal8Bit(pw->pw_dir));
+        }
+        return info;
+    }
+
     QList<QPair<QString, QString>> createdDirs;
     QList<QPair<QString, QString>> copiedFiles;
 };

--- a/tests/test_sessionrunner.cpp
+++ b/tests/test_sessionrunner.cpp
@@ -22,6 +22,7 @@
 #define private public
 #include "CouchPlayHelperClient.h"
 #undef private
+#include "UserLookup.h"
 
 class MockCouchPlayHelperClient : public CouchPlayHelperClient
 {
@@ -43,6 +44,8 @@ public:
 
     QList<AclCall> aclCalls;
     QList<MountCall> mountCalls;
+    struct DeviceOwnerCall { QString path; int uid; };
+    QList<DeviceOwnerCall> deviceOwnerCalls;
 
     explicit MockCouchPlayHelperClient(QObject *parent = nullptr)
         : CouchPlayHelperClient(parent)
@@ -60,6 +63,27 @@ public:
     {
         mountCalls.append({username, compositorUid, directories});
         return directories.size();
+    }
+    bool setDeviceOwner(const QString &devicePath, int uid) override
+    {
+        deviceOwnerCalls.append({devicePath, uid});
+        return true;
+    }
+
+    QVariantMap getUserInfo(const QString &username) override
+    {
+        QVariantMap info;
+        if (username == QStringLiteral("player1")) {
+            info.insert(QStringLiteral("uid"), 1001u);
+            info.insert(QStringLiteral("gid"), 1001u);
+            info.insert(QStringLiteral("home"), QStringLiteral("/home/player1"));
+        }
+        return info;
+    }
+
+    bool isInCouchPlayGroup(const QString &username) override
+    {
+        return username == QStringLiteral("player1");
     }
 };
 
@@ -85,6 +109,8 @@ private Q_SLOTS:
     void testSetupSteamConfigSteamIntegrationDisabled();
     void testSetupSteamConfigAppliesHeroicAcls();
     void testStartSessionHeroicPresetUsesAclsAndSharedConfig();
+    void testResolveUserIdentityViaHelper();
+    void testResolveUserIdentityFallback();
 
 private:
     void createMockHeroicConfig(const QString &basePath);
@@ -322,6 +348,21 @@ void TestSessionRunner::testStartSessionHeroicPresetUsesAclsAndSharedConfig()
     QCOMPARE(m_helperClient->aclCalls.size(), 1);
     QCOMPARE(m_helperClient->aclCalls[0].path, expectedPath);
     QCOMPARE(m_helperClient->aclCalls[0].username, sessionUser);
+}
+
+void TestSessionRunner::testResolveUserIdentityViaHelper()
+{
+    const UserIdentity id = resolveUserIdentity(QStringLiteral("player1"), m_helperClient);
+    QVERIFY(id.valid);
+    QCOMPARE(id.uid, 1001u);
+    QCOMPARE(id.gid, 1001u);
+    QCOMPARE(id.home, QStringLiteral("/home/player1"));
+}
+
+void TestSessionRunner::testResolveUserIdentityFallback()
+{
+    const UserIdentity id = resolveUserIdentity(QStringLiteral("root"), nullptr);
+    QVERIFY(id.valid);
 }
 
 QTEST_MAIN(TestSessionRunner)

--- a/tests/test_usermanager.cpp
+++ b/tests/test_usermanager.cpp
@@ -6,6 +6,19 @@
 #include <unistd.h>
 
 #include "UserManager.h"
+#include "CouchPlayHelperClient.h"
+
+class MockCouchPlayHelperClient : public CouchPlayHelperClient
+{
+    Q_OBJECT
+public:
+    using CouchPlayHelperClient::CouchPlayHelperClient;
+    bool isAvailable() const override { return true; }
+    QStringList listCouchPlayUsers() override
+    {
+        return {QStringLiteral("player1\t1001\t1001\t/home/player1\t/bin/bash")};
+    }
+};
 
 class TestUserManager : public QObject
 {
@@ -60,6 +73,7 @@ private Q_SLOTS:
 
     // Refresh tests
     void testRefreshEmitsSignal();
+    void testParseUsersViaHelper();
 
 private:
     UserManager *m_manager = nullptr;
@@ -364,6 +378,29 @@ void TestUserManager::testRefreshEmitsSignal()
     m_manager->refresh();
 
     QCOMPARE(spy.count(), 1);
+}
+
+void TestUserManager::testParseUsersViaHelper()
+{
+    MockCouchPlayHelperClient *mock = new MockCouchPlayHelperClient();
+    m_manager->setHelperClient(mock);
+
+    QSignalSpy spy(m_manager, &UserManager::usersChanged);
+    m_manager->refresh();
+    QCOMPARE(spy.count(), 1);
+
+    const QVariantList users = m_manager->usersAsVariant();
+    bool found = false;
+    for (const QVariant &v : users) {
+        if (v.toMap().value(QStringLiteral("username")).toString() == QStringLiteral("player1")) {
+            found = true;
+            break;
+        }
+    }
+    QVERIFY2(found, "player1 should appear when the helper provides it");
+
+    m_manager->setHelperClient(nullptr);
+    delete mock;
 }
 
 QTEST_MAIN(TestUserManager)


### PR DESCRIPTION
Fixes the user-list / device-assignment / sharing breakage in the Flatpak from #37.

## Root cause
@waterfoul diagnosed it in the thread: `UserManager.cpp` reads `/etc/passwd` directly, but the Flatpak sandbox has its own (near-empty) `/etc` — so the GUI can't see host users (created-but-invisible), can't assign devices per-player, and Steam/Heroic sharing resolves no target home. The same sandbox isolation breaks every `getpwnam`/`getgrnam` call, not just the list read.

Confirmed on the host: the `couchplay` group (`couch5,couch2,notaname,couch3`) is invisible inside `flatpak run` — `getent group couchplay` returns nothing; sandbox `/etc/passwd` is 2 lines vs the host's 5.

## Fix — make the root D-Bus helper the single source of host user identity
It runs on the host and sees the real `/etc`; the GUI asks it instead of reading `/etc` itself.
- **helper**: ungated `ListCouchPlayUsers()` + `GetUserInfo(username)` D-Bus methods
- **client**: `listCouchPlayUsers` / `getUserInfo` / `isInCouchPlayGroup` proxies; `setDeviceOwner` + `isInCouchPlayGroup` made virtual
- **`UserLookup.h`**: `resolveUserIdentity()` — helper when available, else libc fallback (dev/tests)
- **route every GUI host-user lookup**: UserManager (list/userExists/current-user), SessionRunner (group-check + device-ownership ×3 + compositor-user), SteamConfigManager (×4), HeroicConfigManager (×2), StreamManager (plumbed)
- `getenv("USER")` for the current user (sandbox-safe; `getpwuid` reads sandbox `/etc`)
- manifest: `--device=input` (gamepad classification + rumble need `/dev/input/event*`)
- **install-helper.sh**: detect the flatpak-export layout (binary at script-dir root); make the PipeWire config step optional

### Why this over `/run/host/etc/passwd`
`/run/host/etc/passwd` fixes only the `QFile` list read. The `getpwnam`/`getgrnam` lookups elsewhere (session-start validation, device-ownership uid, Steam/Heroic target-home) still go through libc NSS against the sandbox and break. Routing through the helper fixes all of them consistently.

## Verification
- **18/18 unit tests green** (helper `ListCouchPlayUsers`/`GetUserInfo` + filters, UserManager-via-helper, SessionRunner `resolveUserIdentity`).
- **End-to-end on the Bazzite host**: `flatpak run --command=sh io.github.hikaps.couchplay -c 'gdbus call … ListCouchPlayUsers'` returns the real host users (`couch5/couch2/notaname/couch3`) — the sandbox reaches the helper via the `--system-talk-name`, exactly the GUI's path.
- `/etc` isolation confirmed (`getgrnam("couchplay")` null in-sandbox); `--device=input` confirmed (`/dev/input/event0` readable).

## Complementary
#43 (PlayStation controller detection) touches `DeviceManager`/`VirtualDeviceWatcher` only — no file overlap; together these round out the SteamOS/Flatpak controller story.

## Known follow-ups (non-blocking)
- `export_helper` doesn't copy `data/pipewire/` into the export — the conditional-install fix papers over it; needs a flatpak rebuild to bake fully.
- Latent: the manifest's polkit `-Dlibdir=lib` conflicts with flatpak-builder ≥1.4.8 (`--libdir`); CI's older builder is fine today but will break when `ubuntu-latest` refreshes.
