### PR TITLE
feat: Add support for steam controllers

### DIFF
--- a/src/core/DeviceManager.cpp
+++ b/src/core/DeviceManager.cpp
@@ -9,6 +9,7 @@
 #include <QFile>
 #include <QRegularExpression>
 #include <QTextStream>
+#include <QThread>
 
 // For device identification (rumble)
 #include <cerrno>
@@ -16,6 +17,15 @@
 #include <linux/input.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+
+static QString getBasePhysPath(const QString &physPath)
+{
+    int idx = physPath.lastIndexOf(QStringLiteral("/input"));
+    if (idx != -1) {
+        return physPath.left(idx);
+    }
+    return physPath;
+}
 
 DeviceManager::DeviceManager(QObject *parent)
     : QObject(parent)
@@ -186,10 +196,14 @@ void DeviceManager::refresh()
 
 void DeviceManager::parseDevices()
 {
-    QFile file(QStringLiteral("/proc/bus/input/devices"));
+    QString devicesPath = qEnvironmentVariable("COUCHPLAY_MOCK_DEVICES_FILE");
+    if (devicesPath.isEmpty()) {
+        devicesPath = QStringLiteral("/proc/bus/input/devices");
+    }
+    QFile file(devicesPath);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qWarning() << "DeviceManager: Failed to open /proc/bus/input/devices";
-        Q_EMIT errorOccurred(QStringLiteral("Failed to open /proc/bus/input/devices"));
+        qWarning() << "DeviceManager: Failed to open" << devicesPath;
+        Q_EMIT errorOccurred(QStringLiteral("Failed to open %1").arg(devicesPath));
         return;
     }
 
@@ -233,6 +247,26 @@ void DeviceManager::parseDevices()
         }
     };
 
+    auto formatSteamControllerName = [](InputDevice &device) {
+        if (device.type == QStringLiteral("controller") && device.name.toLower().contains(QStringLiteral("steam controller"))) {
+            int slotIndex = -1;
+            QRegularExpression inputRegex(QStringLiteral("input(\\d+)"));
+            QRegularExpressionMatch match = inputRegex.match(device.physPath);
+            if (match.hasMatch()) {
+                int inputNum = match.captured(1).toInt();
+                if (inputNum >= 2 && inputNum <= 5) {
+                    slotIndex = inputNum - 1;
+                }
+            }
+
+            if (slotIndex >= 1 && slotIndex <= 4) {
+                device.name = QStringLiteral("Steam Controller (Slot %1)").arg(slotIndex);
+            } else {
+                device.name = QStringLiteral("Steam Controller");
+            }
+        }
+    };
+
     while (!stream.atEnd()) {
         QString line = stream.readLine();
         lineCount++;
@@ -264,6 +298,7 @@ void DeviceManager::parseDevices()
                 device.isInternal = isInternalDevice(currentName);
 
                 resolveHidraw(device);
+                formatSteamControllerName(device);
 
                 if (m_settingsManager && m_settingsManager->ignoredDevices().contains(device.stableId)) {
                     qDebug() << "DeviceManager: Ignoring device" << device.name << "stableId:" << device.stableId;
@@ -354,6 +389,7 @@ void DeviceManager::parseDevices()
         device.isInternal = isInternalDevice(currentName);
 
         resolveHidraw(device);
+        formatSteamControllerName(device);
 
         if (m_settingsManager && m_settingsManager->ignoredDevices().contains(device.stableId)) {
             qDebug() << "DeviceManager: Ignoring device" << device.name << "stableId:" << device.stableId;
@@ -380,18 +416,35 @@ QString DeviceManager::detectDeviceType(const QString &name, const QString &hand
         || (lowerHandlers.contains(QStringLiteral("js")) && !lowerName.contains(QStringLiteral("mouse"))
             && !lowerName.contains(QStringLiteral("keyboard")))) {
         // Extra check: If it claims to be a controller but has no buttons, it's likely a wireless receiver with no
-        // controller connected We can check this by trying to open the device and querying capabilities However, we
+        // controller connected. We can check this by trying to open the device and querying capabilities. However, we
         // need to be careful about permissions. If we can't open it, we assume it's valid to avoid blocking valid
         // devices due to permission issues. But for "ghost" devices that are readable (like event8 in the user report),
         // this check will filter them out.
+        // Steam Controllers without Steam running do not report gamepad buttons because they start in Lizard Mode,
+        // so we bypass this check for Steam Controllers.
+        const bool isSteamController = lowerName.contains(QStringLiteral("steam controller"));
+        if (isSteamController) {
+            // For Steam Controllers, we only treat the mouse or the main gamepad interface as the controller device.
+            // We ignore the keyboard interface (treating it as "other") to avoid duplicate entries in the UI.
+            // Sibling propagation will ensure the keyboard interface is assigned alongside the mouse/main device.
+            if (lowerName.contains(QStringLiteral("keyboard"))) {
+                return QStringLiteral("other");
+            }
 
-        QString path = QStringLiteral("/dev/input/event%1")
-                           .arg(handlers.section(QStringLiteral("event"), 1, 1).section(QLatin1Char(' '), 0, 0));
-        if (!path.isEmpty()) {
-            int fd = open(path.toLocal8Bit().constData(), O_RDONLY);
+            QString eventPart = handlers.section(QStringLiteral("event"), 1, 1).section(QLatin1Char(' '), 0, 0);
+            if (!eventPart.isEmpty()) {
+                if (!isSlotConnected(eventPart.toInt())) {
+                    qDebug() << "DeviceManager: Steam Controller slot event" << eventPart << "is disconnected, hiding it.";
+                    return QStringLiteral("other");
+                }
+            }
+        } else {
+            QString path = QStringLiteral("/dev/input/event%1")
+                               .arg(handlers.section(QStringLiteral("event"), 1, 1).section(QLatin1Char(' '), 0, 0));
+            int fd = openDevice(path, O_RDONLY);
             if (fd >= 0) {
                 unsigned char keyBitmask[KEY_MAX / 8 + 1] = {0};
-                if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keyBitmask)), keyBitmask) >= 0) {
+                if (ioctlDevice(fd, EVIOCGBIT(EV_KEY, sizeof(keyBitmask)), keyBitmask) >= 0) {
                     bool hasGamepadBtns = false;
                     // BTN_GAMEPAD is 0x130 (304)
                     for (int i = 0x130; i < 0x140; i++) {
@@ -401,13 +454,13 @@ QString DeviceManager::detectDeviceType(const QString &name, const QString &hand
                         }
                     }
 
-                    close(fd);
+                    closeDevice(fd);
                     if (!hasGamepadBtns) {
                         qDebug() << "DeviceManager: Device" << name << "ignored (no gamepad buttons)";
                         return QStringLiteral("other");
                     }
                 } else {
-                    close(fd);
+                    closeDevice(fd);
                 }
             }
         }
@@ -475,15 +528,43 @@ bool DeviceManager::assignDevice(int eventNumber, int instanceIndex)
     for (int i = 0; i < m_devices.size(); ++i) {
         if (m_devices[i].eventNumber == eventNumber) {
             int previousInstance = m_devices[i].assignedInstance;
-            m_devices[i].assigned = (instanceIndex >= 0);
-            m_devices[i].assignedInstance = instanceIndex;
+            bool assigned = (instanceIndex >= 0);
 
-            // Update persistent assignment cache
-            if (!m_devices[i].stableId.isEmpty()) {
-                if (instanceIndex >= 0) {
-                    m_assignmentCache[m_devices[i].stableId] = qMakePair(instanceIndex, m_devices[i].name);
-                } else {
-                    m_assignmentCache.remove(m_devices[i].stableId);
+            // Assign this device and all siblings on the same physical path if it is a Steam Controller or PlayStation controller
+            QString basePhys = getBasePhysPath(m_devices[i].physPath);
+            bool isGroupedDevice = false;
+            QString lowerName = m_devices[i].name.toLower();
+            if (lowerName.contains(QStringLiteral("steam controller")) ||
+                lowerName.contains(QStringLiteral("wireless controller")) ||
+                lowerName.contains(QStringLiteral("dualshock")) ||
+                lowerName.contains(QStringLiteral("dualsense")) ||
+                lowerName.contains(QStringLiteral("sony"))) {
+                isGroupedDevice = true;
+            }
+
+            if (!basePhys.isEmpty() && isGroupedDevice) {
+                for (auto &device : m_devices) {
+                    if (getBasePhysPath(device.physPath) == basePhys) {
+                        device.assigned = assigned;
+                        device.assignedInstance = instanceIndex;
+                        if (!device.stableId.isEmpty()) {
+                            if (assigned) {
+                                m_assignmentCache[device.stableId] = qMakePair(instanceIndex, device.name);
+                            } else {
+                                m_assignmentCache.remove(device.stableId);
+                            }
+                        }
+                    }
+                }
+            } else {
+                m_devices[i].assigned = assigned;
+                m_devices[i].assignedInstance = instanceIndex;
+                if (!m_devices[i].stableId.isEmpty()) {
+                    if (assigned) {
+                        m_assignmentCache[m_devices[i].stableId] = qMakePair(instanceIndex, m_devices[i].name);
+                    } else {
+                        m_assignmentCache.remove(m_devices[i].stableId);
+                    }
                 }
             }
 
@@ -551,7 +632,7 @@ QStringList DeviceManager::getHidrawPathsForInstance(int instanceIndex) const
 int DeviceManager::autoAssignControllers()
 {
     for (auto &device : m_devices) {
-        if (device.type == QStringLiteral("controller")) {
+        if (device.type == QStringLiteral("controller") || device.name.toLower().contains(QStringLiteral("steam controller"))) {
             device.assigned = false;
             device.assignedInstance = -1;
             if (!device.stableId.isEmpty()) {
@@ -571,11 +652,37 @@ int DeviceManager::autoAssignControllers()
     for (int instance = 0; instance < m_instanceCount && assignedCount < controllerIndices.size(); ++instance) {
         int deviceIndex = controllerIndices[assignedCount];
         int previousInstance = m_devices[deviceIndex].assignedInstance;
-        m_devices[deviceIndex].assigned = true;
-        m_devices[deviceIndex].assignedInstance = instance;
-        if (!m_devices[deviceIndex].stableId.isEmpty()) {
-            m_assignmentCache[m_devices[deviceIndex].stableId] = qMakePair(instance, m_devices[deviceIndex].name);
+
+        bool assigned = true;
+        QString basePhys = getBasePhysPath(m_devices[deviceIndex].physPath);
+        bool isGroupedDevice = false;
+        QString lowerName = m_devices[deviceIndex].name.toLower();
+        if (lowerName.contains(QStringLiteral("steam controller")) ||
+            lowerName.contains(QStringLiteral("wireless controller")) ||
+            lowerName.contains(QStringLiteral("dualshock")) ||
+            lowerName.contains(QStringLiteral("dualsense")) ||
+            lowerName.contains(QStringLiteral("sony"))) {
+            isGroupedDevice = true;
         }
+
+        if (!basePhys.isEmpty() && isGroupedDevice) {
+            for (auto &device : m_devices) {
+                if (getBasePhysPath(device.physPath) == basePhys) {
+                    device.assigned = assigned;
+                    device.assignedInstance = instance;
+                    if (!device.stableId.isEmpty()) {
+                        m_assignmentCache[device.stableId] = qMakePair(instance, device.name);
+                    }
+                }
+            }
+        } else {
+            m_devices[deviceIndex].assigned = assigned;
+            m_devices[deviceIndex].assignedInstance = instance;
+            if (!m_devices[deviceIndex].stableId.isEmpty()) {
+                m_assignmentCache[m_devices[deviceIndex].stableId] = qMakePair(instance, m_devices[deviceIndex].name);
+            }
+        }
+
         Q_EMIT deviceAssigned(m_devices[deviceIndex].eventNumber, instance, previousInstance);
         assignedCount++;
     }
@@ -719,6 +826,25 @@ QVariantList DeviceManager::visibleDevicesAsVariant() const
             continue;
         }
 
+        // For Steam Controllers, if there are multiple devices on the same base physical path,
+        // we only show the one that has a slot index (the formatted puck mouse node)
+        // to prevent duplicate UI entries.
+        if (device.type == QStringLiteral("controller") && device.name.toLower().contains(QStringLiteral("steam controller"))) {
+            if (!device.name.contains(QStringLiteral("Slot"))) {
+                QString basePhys = getBasePhysPath(device.physPath);
+                bool hasSlotDevice = false;
+                for (const auto &other : m_devices) {
+                    if (other.name.contains(QStringLiteral("Slot")) && getBasePhysPath(other.physPath) == basePhys) {
+                        hasSlotDevice = true;
+                        break;
+                    }
+                }
+                if (hasSlotDevice) {
+                    continue; // Skip/hide this duplicate gamepad node
+                }
+            }
+        }
+
         list.append(deviceToVariantMap(device));
     }
     return list;
@@ -732,6 +858,26 @@ QVariantList DeviceManager::controllersAsVariant() const
             if (!m_showVirtualDevices && device.isVirtual) {
                 continue;
             }
+
+            // For Steam Controllers, if there are multiple devices on the same base physical path,
+            // we only show the one that has a slot index (the formatted puck mouse node)
+            // to prevent duplicate UI entries.
+            if (device.name.toLower().contains(QStringLiteral("steam controller"))) {
+                if (!device.name.contains(QStringLiteral("Slot"))) {
+                    QString basePhys = getBasePhysPath(device.physPath);
+                    bool hasSlotDevice = false;
+                    for (const auto &other : m_devices) {
+                        if (other.name.contains(QStringLiteral("Slot")) && getBasePhysPath(other.physPath) == basePhys) {
+                            hasSlotDevice = true;
+                            break;
+                        }
+                    }
+                    if (hasSlotDevice) {
+                        continue; // Skip/hide this duplicate gamepad node
+                    }
+                }
+            }
+
             list.append(deviceToVariantMap(device));
         }
     }
@@ -1015,3 +1161,65 @@ QString DeviceManager::findHidrawForEvent(int eventNumber) const
 
     return QString();
 }
+
+int DeviceManager::openDevice(const QString &path, int flags) const
+{
+    return open(path.toLocal8Bit().constData(), flags);
+}
+
+int DeviceManager::ioctlDevice(int fd, unsigned long request, void *arg) const
+{
+    return ioctl(fd, request, arg);
+}
+
+void DeviceManager::closeDevice(int fd) const
+{
+    close(fd);
+}
+
+bool DeviceManager::isSlotConnected(int eventNumber) const
+{
+    // Find the hidraw path for this event device
+    QString hidrawPath = findHidrawForEvent(eventNumber);
+    if (!hidrawPath.isEmpty()) {
+        int fd = ::open(hidrawPath.toLocal8Bit().constData(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+        if (fd >= 0) {
+            // Wait 10 milliseconds for any pending packets
+            QThread::msleep(10);
+
+            unsigned char buf[64];
+            int bytes = ::read(fd, buf, sizeof(buf));
+            ::close(fd);
+
+            if (bytes > 0) {
+                qDebug() << "DeviceManager: Steam Controller on" << hidrawPath << "is CONNECTED (read" << bytes << "bytes)";
+                return true;
+            } else if (bytes < 0 && (errno == EAGAIN
+#if defined(EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
+                                    || errno == EWOULDBLOCK
+#endif
+                                    )) {
+                qDebug() << "DeviceManager: Steam Controller on" << hidrawPath << "is DISCONNECTED (EAGAIN)";
+                return false;
+            }
+        } else {
+            qDebug() << "DeviceManager: Failed to open" << hidrawPath << "for status check:" << strerror(errno);
+        }
+    }
+
+    // Fallback 1: Check power_supply if driver is hid-steam
+    QString basePath = QStringLiteral("/sys/class/input/event%1/device").arg(eventNumber);
+    QString driverPath = QFile::symLinkTarget(basePath + QStringLiteral("/device/driver"));
+    bool isHidSteam = driverPath.endsWith(QStringLiteral("hid-steam"));
+
+    if (isHidSteam) {
+        bool hasBattery = QDir(basePath + QStringLiteral("/device/power_supply")).exists();
+        if (!hasBattery) {
+            return false;
+        }
+    }
+
+    // Fallback 2: Default to true (assume connected) if we can't determine
+    return true;
+}
+

--- a/src/core/DeviceManager.cpp
+++ b/src/core/DeviceManager.cpp
@@ -18,13 +18,29 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
-static QString getBasePhysPath(const QString &physPath)
+static QString getGroupingPath(const QString &physPath, const QString &name)
 {
-    int idx = physPath.lastIndexOf(QStringLiteral("/input"));
-    if (idx != -1) {
-        return physPath.left(idx);
+    if (physPath.isEmpty()) {
+        return physPath;
     }
-    return physPath;
+
+    bool isSteam = name.toLower().contains(QStringLiteral("steam controller"));
+    if (isSteam) {
+        // Group by Steam Controller Slot (keeps input2, input3, etc. separate)
+        int firstIdx = physPath.indexOf(QStringLiteral("/input"));
+        int lastIdx = physPath.lastIndexOf(QStringLiteral("/input"));
+        if (firstIdx != -1 && lastIdx != -1 && firstIdx != lastIdx) {
+            return physPath.left(lastIdx);
+        }
+        return physPath;
+    } else {
+        // Group by Base USB path for PlayStation and other controllers
+        int idx = physPath.lastIndexOf(QStringLiteral("/input"));
+        if (idx != -1) {
+            return physPath.left(idx);
+        }
+        return physPath;
+    }
 }
 
 DeviceManager::DeviceManager(QObject *parent)
@@ -531,7 +547,7 @@ bool DeviceManager::assignDevice(int eventNumber, int instanceIndex)
             bool assigned = (instanceIndex >= 0);
 
             // Assign this device and all siblings on the same physical path if it is a Steam Controller or PlayStation controller
-            QString basePhys = getBasePhysPath(m_devices[i].physPath);
+            QString basePhys = getGroupingPath(m_devices[i].physPath, m_devices[i].name);
             bool isGroupedDevice = false;
             QString lowerName = m_devices[i].name.toLower();
             if (lowerName.contains(QStringLiteral("steam controller")) ||
@@ -544,7 +560,7 @@ bool DeviceManager::assignDevice(int eventNumber, int instanceIndex)
 
             if (!basePhys.isEmpty() && isGroupedDevice) {
                 for (auto &device : m_devices) {
-                    if (getBasePhysPath(device.physPath) == basePhys) {
+                    if (getGroupingPath(device.physPath, device.name) == basePhys) {
                         device.assigned = assigned;
                         device.assignedInstance = instanceIndex;
                         if (!device.stableId.isEmpty()) {
@@ -654,7 +670,7 @@ int DeviceManager::autoAssignControllers()
         int previousInstance = m_devices[deviceIndex].assignedInstance;
 
         bool assigned = true;
-        QString basePhys = getBasePhysPath(m_devices[deviceIndex].physPath);
+        QString basePhys = getGroupingPath(m_devices[deviceIndex].physPath, m_devices[deviceIndex].name);
         bool isGroupedDevice = false;
         QString lowerName = m_devices[deviceIndex].name.toLower();
         if (lowerName.contains(QStringLiteral("steam controller")) ||
@@ -667,7 +683,7 @@ int DeviceManager::autoAssignControllers()
 
         if (!basePhys.isEmpty() && isGroupedDevice) {
             for (auto &device : m_devices) {
-                if (getBasePhysPath(device.physPath) == basePhys) {
+                if (getGroupingPath(device.physPath, device.name) == basePhys) {
                     device.assigned = assigned;
                     device.assignedInstance = instance;
                     if (!device.stableId.isEmpty()) {
@@ -826,22 +842,13 @@ QVariantList DeviceManager::visibleDevicesAsVariant() const
             continue;
         }
 
-        // For Steam Controllers, if there are multiple devices on the same base physical path,
-        // we only show the one that has a slot index (the formatted puck mouse node)
-        // to prevent duplicate UI entries.
+        // For Steam Controllers, we only show the primary slot mouse device in the UI.
+        // Child devices (like the dynamically registered gamepad node) have multiple /input segments.
         if (device.type == QStringLiteral("controller") && device.name.toLower().contains(QStringLiteral("steam controller"))) {
-            if (!device.name.contains(QStringLiteral("Slot"))) {
-                QString basePhys = getBasePhysPath(device.physPath);
-                bool hasSlotDevice = false;
-                for (const auto &other : m_devices) {
-                    if (other.name.contains(QStringLiteral("Slot")) && getBasePhysPath(other.physPath) == basePhys) {
-                        hasSlotDevice = true;
-                        break;
-                    }
-                }
-                if (hasSlotDevice) {
-                    continue; // Skip/hide this duplicate gamepad node
-                }
+            int firstIdx = device.physPath.indexOf(QStringLiteral("/input"));
+            int lastIdx = device.physPath.lastIndexOf(QStringLiteral("/input"));
+            if (firstIdx != -1 && lastIdx != -1 && firstIdx != lastIdx) {
+                continue; // Skip/hide this duplicate gamepad node
             }
         }
 
@@ -859,22 +866,13 @@ QVariantList DeviceManager::controllersAsVariant() const
                 continue;
             }
 
-            // For Steam Controllers, if there are multiple devices on the same base physical path,
-            // we only show the one that has a slot index (the formatted puck mouse node)
-            // to prevent duplicate UI entries.
+            // For Steam Controllers, we only show the primary slot mouse device in the UI.
+            // Child devices (like the dynamically registered gamepad node) have multiple /input segments.
             if (device.name.toLower().contains(QStringLiteral("steam controller"))) {
-                if (!device.name.contains(QStringLiteral("Slot"))) {
-                    QString basePhys = getBasePhysPath(device.physPath);
-                    bool hasSlotDevice = false;
-                    for (const auto &other : m_devices) {
-                        if (other.name.contains(QStringLiteral("Slot")) && getBasePhysPath(other.physPath) == basePhys) {
-                            hasSlotDevice = true;
-                            break;
-                        }
-                    }
-                    if (hasSlotDevice) {
-                        continue; // Skip/hide this duplicate gamepad node
-                    }
+                int firstIdx = device.physPath.indexOf(QStringLiteral("/input"));
+                int lastIdx = device.physPath.lastIndexOf(QStringLiteral("/input"));
+                if (firstIdx != -1 && lastIdx != -1 && firstIdx != lastIdx) {
+                    continue; // Skip/hide this duplicate gamepad node
                 }
             }
 

--- a/src/core/DeviceManager.h
+++ b/src/core/DeviceManager.h
@@ -303,6 +303,12 @@ Q_SIGNALS:
     void instanceCountChanged();
     void settingsManagerChanged();
 
+protected:
+    virtual int openDevice(const QString &path, int flags) const;
+    virtual int ioctlDevice(int fd, unsigned long request, void *arg) const;
+    virtual void closeDevice(int fd) const;
+    virtual bool isSlotConnected(int eventNumber) const;
+
 private Q_SLOTS:
     void onInputDirectoryChanged();
     void onDebounceTimeout();

--- a/tests/test_devicemanager.cpp
+++ b/tests/test_devicemanager.cpp
@@ -3,8 +3,10 @@
 
 #include <QSignalSpy>
 #include <QTemporaryDir>
+#include <QSet>
 #include <QTemporaryFile>
 #include <QTest>
+#include <linux/input.h>
 
 #define private public
 #include "DeviceManager.h"
@@ -62,6 +64,8 @@ private Q_SLOTS:
     // Blacklist tests
     void testIgnoredDevices();
     void testIsVirtualDevice();
+    void testSteamControllerDetection();
+    void testPlayStationControllerGrouping();
 
 private:
     DeviceManager *m_deviceManager = nullptr;
@@ -194,7 +198,7 @@ void TestDeviceManager::testGetDevicesForInstance()
 
     // Get devices for instance 0
     QList<int> instanceDevices = m_deviceManager->getDevicesForInstance(0);
-    QCOMPARE(instanceDevices.size(), assignedCount);
+    QVERIFY(instanceDevices.size() >= assignedCount);
 
     // Get devices for unassigned instance
     QList<int> emptyList = m_deviceManager->getDevicesForInstance(1);
@@ -548,7 +552,7 @@ void TestDeviceManager::testGetStableIdsForInstance()
 
     // Get stable IDs for instance 0
     QStringList stableIds = m_deviceManager->getStableIdsForInstance(0);
-    QCOMPARE(stableIds.size(), expectedStableIds.size());
+    QVERIFY(stableIds.size() >= expectedStableIds.size());
 
     for (const QString &id : expectedStableIds) {
         QVERIFY(stableIds.contains(id));
@@ -694,6 +698,322 @@ void TestDeviceManager::testIsVirtualDevice()
     // Test other devices with empty physical path (should be virtual)
     QVERIFY(m_deviceManager->isVirtualDevice(QStringLiteral("Keyboard"), QString(), QStringLiteral("0006")));
     QVERIFY(m_deviceManager->isVirtualDevice(QStringLiteral("Keyboard"), QString(), QString()));
+}
+
+class MockDeviceManager : public DeviceManager
+{
+public:
+    explicit MockDeviceManager(QObject *parent = nullptr) : DeviceManager(parent) {}
+
+    // Mock control flags/variables
+    mutable bool mockIoctlSuccess = false;
+    mutable QByteArray mockKeyBitmask;
+    mutable QString expectedOpenedPath;
+    mutable bool wasOpened = false;
+    mutable QSet<int> mockConnectedSlots;
+
+protected:
+    int openDevice(const QString &path, int flags) const override
+    {
+        Q_UNUSED(flags);
+        if (path == expectedOpenedPath) {
+            wasOpened = true;
+            return 999; // Return dummy fd for expected controller
+        }
+        if (path.contains(QStringLiteral("event"))) {
+            return 888; // Return dummy fd for non-controller event files
+        }
+        // Avoid opening real devices in the unit test
+        return -1;
+    }
+
+    int ioctlDevice(int fd, unsigned long request, void *arg) const override
+    {
+        Q_UNUSED(request);
+        if (fd == 999) {
+            if (mockIoctlSuccess) {
+                int size = KEY_MAX / 8 + 1;
+                unsigned char *bitmask = static_cast<unsigned char *>(arg);
+                memset(bitmask, 0, size);
+                int copySize = qMin(size, mockKeyBitmask.size());
+                memcpy(bitmask, mockKeyBitmask.constData(), copySize);
+                return 0;
+            }
+            return -1;
+        }
+        if (fd == 888) {
+            // Return success but an empty bitmask (no buttons)
+            int size = KEY_MAX / 8 + 1;
+            unsigned char *bitmask = static_cast<unsigned char *>(arg);
+            memset(bitmask, 0, size);
+            return 0;
+        }
+        return -1;
+    }
+
+    void closeDevice(int fd) const override
+    {
+        Q_UNUSED(fd);
+    }
+
+    bool isSlotConnected(int eventNumber) const override
+    {
+        if (mockConnectedSlots.isEmpty()) {
+            return true;
+        }
+        return mockConnectedSlots.contains(eventNumber);
+    }
+};
+
+void TestDeviceManager::testSteamControllerDetection()
+{
+    // Create a temporary file to mock /proc/bus/input/devices
+    QTemporaryFile mockDevicesFile;
+    QVERIFY(mockDevicesFile.open());
+
+    // Write a standard controller and a Steam Controller (in Lizard mode, no gamepad buttons)
+    QTextStream out(&mockDevicesFile);
+    
+    // Write 4 slots of Steam Controller Puck (each has Mouse + Keyboard)
+    // Slot 1
+    out << "I: Bus=0003 Vendor=28de Product=1304 Version=0111\n";
+    out << "N: Name=\"Valve Software Steam Controller Puck Mouse\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input2\n";
+    out << "H: Handlers=event2 mouse0\n\n";
+
+    out << "I: Bus=0003 Vendor=28de Product=1304 Version=0111\n";
+    out << "N: Name=\"Valve Software Steam Controller Puck Keyboard\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input2\n";
+    out << "H: Handlers=sysrq kbd event3\n\n";
+
+    // Actual Gamepad Device (event10)
+    out << "I: Bus=0003 Vendor=28de Product=1102 Version=0011\n";
+    out << "N: Name=\"Valve Software Steam Controller\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input0\n";
+    out << "H: Handlers=event10 js0\n\n";
+
+    // Slot 2
+    out << "I: Bus=0003 Vendor=28de Product=1304 Version=0111\n";
+    out << "N: Name=\"Valve Software Steam Controller Puck Mouse\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input3\n";
+    out << "H: Handlers=event4 mouse1\n\n";
+
+    out << "I: Bus=0003 Vendor=28de Product=1304 Version=0111\n";
+    out << "N: Name=\"Valve Software Steam Controller Puck Keyboard\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input3\n";
+    out << "H: Handlers=sysrq kbd event5\n\n";
+
+    // Slot 3
+    out << "I: Bus=0003 Vendor=28de Product=1304 Version=0111\n";
+    out << "N: Name=\"Valve Software Steam Controller Puck Mouse\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input4\n";
+    out << "H: Handlers=event6 mouse2\n\n";
+
+    out << "I: Bus=0003 Vendor=28de Product=1304 Version=0111\n";
+    out << "N: Name=\"Valve Software Steam Controller Puck Keyboard\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input4\n";
+    out << "H: Handlers=sysrq kbd event7\n\n";
+
+    // Slot 4
+    out << "I: Bus=0003 Vendor=28de Product=1304 Version=0111\n";
+    out << "N: Name=\"Valve Software Steam Controller Puck Mouse\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input5\n";
+    out << "H: Handlers=event8 mouse3\n\n";
+
+    out << "I: Bus=0003 Vendor=28de Product=1304 Version=0111\n";
+    out << "N: Name=\"Valve Software Steam Controller Puck Keyboard\"\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input5\n";
+    out << "H: Handlers=sysrq kbd event9\n\n";
+
+    // Xbox Controller
+    out << "I: Bus=0003 Vendor=045e Product=028e Version=0110\n";
+    out << "N: Name=\"Microsoft X-Box 360 pad\"\n";
+    out << "P: Phys=usb-0000:00:14.0-2/input0\n";
+    out << "H: Handlers=event8888 js0\n\n";
+    
+    out.flush();
+    mockDevicesFile.close();
+
+    // Set mock env var
+    qputenv("COUCHPLAY_MOCK_DEVICES_FILE", mockDevicesFile.fileName().toLocal8Bit());
+
+    // Create MockDeviceManager
+    MockDeviceManager mockManager;
+    
+    // Mock only Slot 1 connected, others disconnected
+    mockManager.mockConnectedSlots = {2, 3, 10};
+
+    // Set up mock responses:
+    // For event8888 (Xbox pad), we mock ioctl to succeed and return gamepad buttons
+    // So it should be detected as a controller
+    mockManager.expectedOpenedPath = QStringLiteral("/dev/input/event8888");
+    mockManager.mockIoctlSuccess = true;
+    
+    // BTN_GAMEPAD is 0x130 (304). Let's set the bit in mockKeyBitmask.
+    // 304 / 8 = 38. So byte index 38 has bit 304 % 8 = 0 set.
+    QByteArray xboxBitmask(KEY_MAX / 8 + 1, 0);
+    xboxBitmask[38] = 0x01; // BTN_GAMEPAD (BTN_A)
+    mockManager.mockKeyBitmask = xboxBitmask;
+
+    mockManager.refresh();
+
+    // Verify list size & types
+    QVariantList controllers = mockManager.controllersAsVariant();
+    
+    // Should be exactly 2 controllers: 1 active Steam Controller (Slot 1) + 1 Xbox gamepad
+    // The disconnected Steam Controller slots (2, 3, 4) should be hidden (classified as other)!
+    QCOMPARE(controllers.size(), 2);
+
+    int puckCount = 0;
+    int xboxCount = 0;
+
+    for (const QVariant &v : controllers) {
+        QVariantMap dev = v.toMap();
+        QString name = dev.value(KEY("name")).toString();
+        if (name.contains(QStringLiteral("Steam Controller (Slot"))) {
+            puckCount++;
+            QCOMPARE(name, QStringLiteral("Steam Controller (Slot 1)"));
+            QCOMPARE(dev.value(KEY("type")).toString(), QStringLiteral("controller"));
+        } else if (name == QStringLiteral("Microsoft X-Box 360 pad")) {
+            xboxCount++;
+            QCOMPARE(dev.value(KEY("type")).toString(), QStringLiteral("controller"));
+        }
+    }
+
+    QCOMPARE(puckCount, 1);
+    QCOMPARE(xboxCount, 1);
+
+    // Verify Sibling Assignment Propagation
+    // Assign Puck Slot 1 Mouse (event2) to instance 0
+    QVERIFY(mockManager.assignDevice(2, 0));
+
+    // Verify event2 is assigned to 0
+    QVariantMap mouseDev = mockManager.getDevice(2);
+    QCOMPARE(mouseDev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(mouseDev.value(KEY("assignedInstance")).toInt(), 0);
+
+    // Verify event3 (Keyboard) was automatically assigned to 0 as well!
+    QVariantMap kbdDev = mockManager.getDevice(3);
+    QCOMPARE(kbdDev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(kbdDev.value(KEY("assignedInstance")).toInt(), 0);
+
+    // Verify event10 (Actual Gamepad) was automatically assigned to 0 as well!
+    QVariantMap padDev = mockManager.getDevice(10);
+    QCOMPARE(padDev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(padDev.value(KEY("assignedInstance")).toInt(), 0);
+
+    // Unassign Puck Slot 1 Mouse (event2)
+    QVERIFY(mockManager.assignDevice(2, -1));
+
+    // Verify both are now unassigned
+    mouseDev = mockManager.getDevice(2);
+    QCOMPARE(mouseDev.value(KEY("assigned")).toBool(), false);
+    QCOMPARE(mouseDev.value(KEY("assignedInstance")).toInt(), -1);
+
+    kbdDev = mockManager.getDevice(3);
+    QCOMPARE(kbdDev.value(KEY("assigned")).toBool(), false);
+    QCOMPARE(kbdDev.value(KEY("assignedInstance")).toInt(), -1);
+
+    // Verify event10 is now unassigned
+    padDev = mockManager.getDevice(10);
+    QCOMPARE(padDev.value(KEY("assigned")).toBool(), false);
+    QCOMPARE(padDev.value(KEY("assignedInstance")).toInt(), -1);
+
+    // Verify autoAssignControllers also assigns siblings
+    mockManager.autoAssignControllers();
+
+    // Verify event2 & event3 & event10 are assigned to same instance
+    mouseDev = mockManager.getDevice(2);
+    kbdDev = mockManager.getDevice(3);
+    padDev = mockManager.getDevice(10);
+    QCOMPARE(mouseDev.value(KEY("assigned")).toBool(), kbdDev.value(KEY("assigned")).toBool());
+    QCOMPARE(mouseDev.value(KEY("assignedInstance")).toInt(), kbdDev.value(KEY("assignedInstance")).toInt());
+    QCOMPARE(mouseDev.value(KEY("assigned")).toBool(), padDev.value(KEY("assigned")).toBool());
+    QCOMPARE(mouseDev.value(KEY("assignedInstance")).toInt(), padDev.value(KEY("assignedInstance")).toInt());
+
+    // Clean up env
+    qunsetenv("COUCHPLAY_MOCK_DEVICES_FILE");
+}
+
+void TestDeviceManager::testPlayStationControllerGrouping()
+{
+    // Create a temporary file to mock /proc/bus/input/devices
+    QTemporaryFile mockDevicesFile;
+    QVERIFY(mockDevicesFile.open());
+
+    QTextStream out(&mockDevicesFile);
+
+    // DualSense Controller Sibling 1 (Gamepad)
+    out << "I: Bus=0003 Vendor=054c Product=0ce6 Version=0111\n";
+    out << "N: Name=\"Sony Interactive Entertainment Wireless Controller\"\n";
+    out << "P: Phys=usb-0000:12:00.4-2/input0\n";
+    out << "H: Handlers=event20 js0\n\n";
+
+    // DualSense Controller Sibling 2 (Touchpad)
+    out << "I: Bus=0003 Vendor=054c Product=0ce6 Version=0111\n";
+    out << "N: Name=\"Sony Interactive Entertainment Wireless Controller Touchpad\"\n";
+    out << "P: Phys=usb-0000:12:00.4-2/input1\n";
+    out << "H: Handlers=event21 mouse1\n\n";
+
+    // DualSense Controller Sibling 3 (Motion Sensors)
+    out << "I: Bus=0003 Vendor=054c Product=0ce6 Version=0111\n";
+    out << "N: Name=\"Sony Interactive Entertainment Wireless Controller Motion Sensors\"\n";
+    out << "P: Phys=usb-0000:12:00.4-2/input2\n";
+    out << "H: Handlers=event22 mouse2\n\n";
+
+    out.flush();
+    mockDevicesFile.close();
+
+    qputenv("COUCHPLAY_MOCK_DEVICES_FILE", mockDevicesFile.fileName().toLocal8Bit());
+
+    MockDeviceManager mockManager;
+    
+    // Mock ioctl success for event20 to return gamepad buttons
+    mockManager.expectedOpenedPath = QStringLiteral("/dev/input/event20");
+    mockManager.mockIoctlSuccess = true;
+    QByteArray dsBitmask(KEY_MAX / 8 + 1, 0);
+    dsBitmask[38] = 0x01; // BTN_GAMEPAD (BTN_A)
+    mockManager.mockKeyBitmask = dsBitmask;
+
+    mockManager.refresh();
+
+    // Verify gamepad is detected as controller, touchpad & motion sensors as "other"
+    QVariantList controllers = mockManager.controllersAsVariant();
+    QCOMPARE(controllers.size(), 1);
+    QCOMPARE(controllers.first().toMap().value(KEY("name")).toString(), QStringLiteral("Sony Interactive Entertainment Wireless Controller"));
+
+    // Verify Sibling Assignment Propagation for PlayStation controller
+    // Assign Sibling 1 (Gamepad, event20) to instance 1
+    QVERIFY(mockManager.assignDevice(20, 1));
+
+    // Verify event20 is assigned to 1
+    QVariantMap padDev = mockManager.getDevice(20);
+    QCOMPARE(padDev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(padDev.value(KEY("assignedInstance")).toInt(), 1);
+
+    // Verify event21 (Touchpad) was automatically assigned to 1 as well!
+    QVariantMap touchDev = mockManager.getDevice(21);
+    QCOMPARE(touchDev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(touchDev.value(KEY("assignedInstance")).toInt(), 1);
+
+    // Verify event22 (Motion Sensors) was automatically assigned to 1 as well!
+    QVariantMap motionDev = mockManager.getDevice(22);
+    QCOMPARE(motionDev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(motionDev.value(KEY("assignedInstance")).toInt(), 1);
+
+    // Unassign Gamepad (event20)
+    QVERIFY(mockManager.assignDevice(20, -1));
+
+    // Verify all are now unassigned
+    padDev = mockManager.getDevice(20);
+    touchDev = mockManager.getDevice(21);
+    motionDev = mockManager.getDevice(22);
+    QCOMPARE(padDev.value(KEY("assigned")).toBool(), false);
+    QCOMPARE(touchDev.value(KEY("assigned")).toBool(), false);
+    QCOMPARE(motionDev.value(KEY("assigned")).toBool(), false);
+
+    // Clean up env
+    qunsetenv("COUCHPLAY_MOCK_DEVICES_FILE");
 }
 
 QTEST_MAIN(TestDeviceManager)

--- a/tests/test_devicemanager.cpp
+++ b/tests/test_devicemanager.cpp
@@ -789,7 +789,7 @@ void TestDeviceManager::testSteamControllerDetection()
     // Actual Gamepad Device (event10)
     out << "I: Bus=0003 Vendor=28de Product=1102 Version=0011\n";
     out << "N: Name=\"Valve Software Steam Controller\"\n";
-    out << "P: Phys=usb-0000:12:00.4-1/input0\n";
+    out << "P: Phys=usb-0000:12:00.4-1/input2/input0\n";
     out << "H: Handlers=event10 js0\n\n";
 
     // Slot 2
@@ -900,6 +900,31 @@ void TestDeviceManager::testSteamControllerDetection()
     // Verify event10 (Actual Gamepad) was automatically assigned to 0 as well!
     QVariantMap padDev = mockManager.getDevice(10);
     QCOMPARE(padDev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(padDev.value(KEY("assignedInstance")).toInt(), 0);
+
+    // Verify Slot 2 devices (event4, event5) remain unassigned!
+    QVariantMap mouse2Dev = mockManager.getDevice(4);
+    QCOMPARE(mouse2Dev.value(KEY("assigned")).toBool(), false);
+    QVariantMap kbd2Dev = mockManager.getDevice(5);
+    QCOMPARE(kbd2Dev.value(KEY("assigned")).toBool(), false);
+
+    // Now assign Slot 2 Mouse (event4) to instance 1
+    QVERIFY(mockManager.assignDevice(4, 1));
+
+    // Verify Slot 2 devices are assigned to 1
+    mouse2Dev = mockManager.getDevice(4);
+    QCOMPARE(mouse2Dev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(mouse2Dev.value(KEY("assignedInstance")).toInt(), 1);
+    kbd2Dev = mockManager.getDevice(5);
+    QCOMPARE(kbd2Dev.value(KEY("assigned")).toBool(), true);
+    QCOMPARE(kbd2Dev.value(KEY("assignedInstance")).toInt(), 1);
+
+    // Verify Slot 1 devices still assigned to 0
+    mouseDev = mockManager.getDevice(2);
+    QCOMPARE(mouseDev.value(KEY("assignedInstance")).toInt(), 0);
+    kbdDev = mockManager.getDevice(3);
+    QCOMPARE(kbdDev.value(KEY("assignedInstance")).toInt(), 0);
+    padDev = mockManager.getDevice(10);
     QCOMPARE(padDev.value(KEY("assignedInstance")).toInt(), 0);
 
     // Unassign Puck Slot 1 Mouse (event2)


### PR DESCRIPTION
This adds support for steam controllers by

- Adding some special handler code for the steam controller devices connected to the puck so they register as controllers
- Adding additional logic to check to see if the controllers are connected before adding them to the list
- Grouping all of the devices for the controller before sending them to the user
- Extend the grouping logic to the playstation controllers since they are also multiple system devices per physical device
Note: I attempted to handle multiple controllers on one puck but I only have one myself so I cannot test it

This contains the code from #43, once that is merged this diff will shorten a bit