### PR TITLE
hardening(steam): stricter bootstrap guard before sharing + orphan bind-mount cleanup

### DIFF
--- a/appiumtests/helpers/mock_helper.py
+++ b/appiumtests/helpers/mock_helper.py
@@ -222,6 +222,10 @@ class MockHelper(dbus.service.Object):
     def GetUserSteamId(self, username):
         return ""
 
+    @dbus.service.method(INTERFACE_NAME, in_signature="s", out_signature="b")
+    def IsSteamBootstrapped(self, username):
+        return True
+
     @dbus.service.method(INTERFACE_NAME, in_signature="", out_signature="as")
     def ListCouchPlayUsers(self):
         entries = []

--- a/helper/CouchPlayHelper.cpp
+++ b/helper/CouchPlayHelper.cpp
@@ -1808,6 +1808,32 @@ QString CouchPlayHelper::GetUserSteamId(const QString &username)
     return QString();
 }
 
+bool CouchPlayHelper::IsSteamBootstrapped(const QString &username)
+{
+    if (!userExists(username)) {
+        sendErrorReply(QDBusError::InvalidArgs, QStringLiteral("User '%1' does not exist").arg(username));
+        return false;
+    }
+
+    QString userHome = getUserHome(username);
+    if (userHome.isEmpty()) {
+        return false;
+    }
+
+    // Bootstrap complete when steam.sh or the ubuntu12_32 binary exists (userdata alone is insufficient).
+    const QStringList roots = {
+        userHome + QStringLiteral("/.local/share/Steam"),
+        userHome + QStringLiteral("/.steam/steam"),
+    };
+    for (const QString &root : roots) {
+        if (m_ops->fileExists(root + QStringLiteral("/steam.sh"))
+            || m_ops->fileExists(root + QStringLiteral("/ubuntu12_32/steam"))) {
+            return true;
+        }
+    }
+    return false;
+}
+
 QString CouchPlayHelper::findGamescopePath()
 {
     QString gamescopePath = QStringLiteral("/usr/bin/gamescope");
@@ -2351,7 +2377,23 @@ void CouchPlayHelper::loadAndReconcileState()
                 isMounted = mountsData.contains(target.toUtf8());
             }
 
-            if (isMounted) {
+            if (!activeUsernames.contains(username)) {
+                // Session gone: umount the orphan instead of re-tracking it.
+                if (isMounted) {
+                    qDebug() << "loadAndReconcileState: Umounting orphaned mount" << target << "for gone session" << username;
+                    QProcess *umountProc = m_ops->createProcess();
+                    m_ops->startProcess(umountProc, QStringLiteral("/usr/bin/umount"), {target});
+                    m_ops->waitForFinished(umountProc, 5000);
+                    if (m_ops->processExitCode(umountProc) != 0) {
+                        QProcess *lazyProc = m_ops->createProcess();
+                        m_ops->startProcess(lazyProc, QStringLiteral("/usr/bin/umount"), {QStringLiteral("-l"), target});
+                        m_ops->waitForFinished(lazyProc, 5000);
+                        delete lazyProc;
+                    }
+                    delete umountProc;
+                }
+                changed = true;
+            } else if (isMounted) {
                 MountInfo info;
                 info.source = mountObj.value(QStringLiteral("source")).toString();
                 info.target = target;

--- a/helper/CouchPlayHelper.h
+++ b/helper/CouchPlayHelper.h
@@ -303,6 +303,16 @@ public Q_SLOTS:
     QString GetUserSteamId(const QString &username);
 
     /**
+     * Check whether Steam's first-run setup has completed for a user.
+     * Looks for Steam's launch script/binary (steam.sh or ubuntu12_32/steam),
+     * not just userdata — a partial or failed bootstrap can leave userdata behind.
+     *
+     * @param username User to check
+     * @return true if Steam's bootstrap content is present
+     */
+    bool IsSteamBootstrapped(const QString &username);
+
+    /**
      * Write content directly to a file in a user's directory
      *
      * Used for writing generated config files (e.g., shortcuts.vdf) directly

--- a/src/core/SteamConfigManager.cpp
+++ b/src/core/SteamConfigManager.cpp
@@ -322,6 +322,12 @@ bool SteamConfigManager::syncShortcutsToUser(const QString &targetUsername)
 
     qCDebug(couchplaySteam) << "Source file:" << sourceFile;
 
+    if (m_helperClient && m_helperClient->isAvailable()
+        && !m_helperClient->isSteamBootstrapped(targetUsername)) {
+        qCWarning(couchplaySteam) << "syncShortcutsToUser failed - Steam not set up for user" << targetUsername;
+        Q_EMIT syncFailed(targetUsername, QStringLiteral("Steam not set up for user (run Steam once first)"));
+        return false;
+    }
     // Get target user's Steam ID
     QString targetSteamId = getTargetSteamUserId(targetUsername);
     if (targetSteamId.isEmpty()) {
@@ -872,6 +878,13 @@ bool SteamConfigManager::shareLibraryToUser(const QString &targetUsername)
     }
     QString targetHome = id.home;
     
+    if (m_helperClient && m_helperClient->isAvailable()
+        && !m_helperClient->isSteamBootstrapped(targetUsername)) {
+        qCWarning(couchplaySteam) << "shareLibraryToUser failed - Target user" << targetUsername
+                                   << "has not completed Steam setup. Launch Steam once first.";
+        Q_EMIT syncFailed(targetUsername, QStringLiteral("Target user has not set up Steam"));
+        return false;
+    }
     QString targetSteamId = getTargetSteamUserId(targetUsername);
     if (targetSteamId.isEmpty()) {
         qCWarning(couchplaySteam) << "shareLibraryToUser failed - Target user" << targetUsername

--- a/src/dbus/CouchPlayHelperClient.cpp
+++ b/src/dbus/CouchPlayHelperClient.cpp
@@ -410,6 +410,23 @@ QString CouchPlayHelperClient::getUserSteamId(const QString &username)
     return reply.value();
 }
 
+bool CouchPlayHelperClient::isSteamBootstrapped(const QString &username)
+{
+    if (!m_available) {
+        qWarning() << "CouchPlayHelperClient: Helper not available";
+        return false;
+    }
+
+    QDBusReply<bool> reply = m_interface->call(QStringLiteral("IsSteamBootstrapped"), username);
+
+    if (!reply.isValid()) {
+        qWarning() << "CouchPlayHelperClient: IsSteamBootstrapped failed:" << reply.error().message();
+        return false;
+    }
+
+    return reply.value();
+}
+
 bool CouchPlayHelperClient::writeFileToUser(const QByteArray &content,
                                             const QString &targetPath,
                                             const QString &username)

--- a/src/dbus/CouchPlayHelperClient.h
+++ b/src/dbus/CouchPlayHelperClient.h
@@ -166,6 +166,13 @@ public:
     Q_INVOKABLE QString getUserSteamId(const QString &username);
 
     /**
+     * @brief Check whether Steam's first-run setup completed for a user
+     * @param username User to check
+     * @return true if Steam's bootstrap content (steam.sh/ubuntu12_32) is present
+     */
+    Q_INVOKABLE virtual bool isSteamBootstrapped(const QString &username);
+
+    /**
      * @brief Write content directly to a file in a user's directory
      * @param content File content as bytes
      * @param targetPath Target file path (will be created/overwritten)

--- a/tests/test_couchplayhelper.cpp
+++ b/tests/test_couchplayhelper.cpp
@@ -374,6 +374,8 @@ private Q_SLOTS:
     void testListCouchPlayUsersFilters();
     void testGetUserInfo();
     void testGetUserInfoNotFound();
+    void testIsSteamBootstrappedTrue();
+    void testIsSteamBootstrappedFalse();
 
     // Device ownership tests
     void testChangeDeviceOwnerInvalidPathNotUnderDevInput();
@@ -816,6 +818,30 @@ void TestCouchPlayHelper::testIsLingerEnabledFalse()
     m_ops->setFileExists(QStringLiteral("/var/lib/systemd/linger/testuser"), false);
 
     QDBusReply<bool> reply = m_dbusInterface->call(QStringLiteral("IsLingerEnabled"), QStringLiteral("testuser"));
+
+    QVERIFY(reply.isValid());
+    QVERIFY(!reply.value());
+}
+
+void TestCouchPlayHelper::testIsSteamBootstrappedTrue()
+{
+    m_ops->clear();
+    m_ops->setUserExists(QStringLiteral("player1"), true, 1001, 1001, QStringLiteral("/home/player1"));
+    m_ops->setFileExists(QStringLiteral("/home/player1/.local/share/Steam/steam.sh"), true);
+
+    QDBusReply<bool> reply = m_dbusInterface->call(QStringLiteral("IsSteamBootstrapped"), QStringLiteral("player1"));
+
+    QVERIFY(reply.isValid());
+    QVERIFY(reply.value());
+}
+
+void TestCouchPlayHelper::testIsSteamBootstrappedFalse()
+{
+    // Home present but no steam.sh (e.g. failed bootstrap left only userdata) — must report not bootstrapped.
+    m_ops->clear();
+    m_ops->setUserExists(QStringLiteral("player1"), true, 1001, 1001, QStringLiteral("/home/player1"));
+
+    QDBusReply<bool> reply = m_dbusInterface->call(QStringLiteral("IsSteamBootstrapped"), QStringLiteral("player1"));
 
     QVERIFY(reply.isValid());
     QVERIFY(!reply.value());


### PR DESCRIPTION
## What this does
Defensive hardening for the Steam library/shortcut-sharing paths — two independent improvements.

### 1. Stricter bootstrap guard
`shareLibraryToUser` and `syncShortcutsToUser` previously gated on `userdata/<id>/` existing, which a partial or failed Steam first-run leaves behind. They now also require the target's Steam install to be genuinely bootstrapped:

- **New helper method `IsSteamBootstrapped(username)`** checks for `steam.sh` or `ubuntu12_32/steam` under the user's Steam root (real bootstrap artifacts), not just `userdata`.
- Both sharing methods bail early (`return false` + `qCWarning`) when the target isn't bootstrapped, so couchplay never writes app manifests or bind-mounts `steamapps/common` into a half-set-up Steam dir.

### 2. Orphan bind-mount cleanup
`loadAndReconcileState` (runs at helper startup) now umounts bind-mounts whose owning user has no active session, instead of silently re-tracking them. Previously an orphaned mount (left by a crashed/killed session) survived helper restarts and was only released at clean shutdown. Now: `umount <target>`, with a lazy `umount -l` fallback.

## Context / scope
This is **hardening, not a bug fix.** It was written while investigating #28 (a CouchPlay-created user stuck on `Error: Couldn't set up Steam data`), but that user's `findmnt` output and Steam directory listing showed a **Steam-side bootstrap crash** — partial extraction with a `.crash` marker and no `steam.sh`, no stale couchplay bind-mounts, and no root-owned files. CouchPlay was not corrupting the directory. Writing into an unbootstrapped `steamRoot` is still undesirable, so the guard is worth landing; the underlying Steam bootstrap crash is tracked separately on #28.

## Tests
- e2e mock helper updated for the new method.
- New unit tests: `testIsSteamBootstrappedTrue` / `False`.
- Full suite: `QT_QPA_PLATFORM=offscreen dbus-run-session -- ctest --test-dir build` → **18/18**.
