### PR TITLE
feat(install): make Flatpak the default one-liner pathway

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -71,12 +71,15 @@ jobs:
       - name: Create Flatpak bundle
         run: |
           flatpak build-bundle repo couchplay.flatpak io.github.hikaps.couchplay stable
+          sha256sum couchplay.flatpak > couchplay.flatpak.sha256
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: flatpak-bundle
-          path: couchplay.flatpak
+          path: |
+            couchplay.flatpak
+            couchplay.flatpak.sha256
 
       - name: Publish Flatpak to beta release
         if: github.ref == 'refs/heads/develop'
@@ -84,10 +87,14 @@ jobs:
         with:
           tag_name: beta
           prerelease: true
-          files: couchplay.flatpak
+          files: |
+            couchplay.flatpak
+            couchplay.flatpak.sha256
 
       - name: Upload to Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: couchplay.flatpak
+          files: |
+            couchplay.flatpak
+            couchplay.flatpak.sha256

--- a/README.md
+++ b/README.md
@@ -104,8 +104,19 @@ curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/insta
 ```
 
 > Requires Linux x86_64 and sudo. On SteamOS the installer also deploys a system extension
-> for the privileged helper. Pass `--tarball` for the native GUI binary (Fedora-family only).
-> Beta builds include unreleased features and may be unstable.
+> for the privileged helper. Beta builds include unreleased features and may be unstable.
+
+### Native binary (tarball, Fedora-family only)
+
+The one-liner defaults to the Flatpak. To install the native `couchplay` GUI binary +
+desktop entry and the privileged helper from the release tarball instead, pass `--tarball`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --tarball
+```
+
+The native GUI only runs on Fedora-family distros (where the system Qt6 matches the
+build); on Arch/SteamOS it fails to start with a copy-relocation error — use the Flatpak.
 
 ### 1. Install the Flatpak (GUI)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ and audio). Install the Flatpak for the GUI, then install the helper.
 > whose Qt6 matches the build (Fedora-family) — on Arch or SteamOS it fails to start with
 > a copy-relocation error, which is why the Flatpak is the recommended GUI everywhere.
 
+### Quick install (recommended)
+
+One command installs the Flatpak GUI and the privileged helper:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash
+```
+
+Beta build (from `develop`):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --beta
+```
+
+> Requires Linux x86_64 and sudo. On SteamOS the installer deploys a system extension
+> instead of the Flatpak. Pass `--tarball` for the native GUI binary (Fedora-family only).
+> Beta builds include unreleased features and may be unstable.
+
 ### 1. Install the Flatpak (GUI)
 
 1. **Download** the `.flatpak` bundle from the [Releases page](../../releases).
@@ -116,18 +134,7 @@ The `export` step stages the helper in the Flatpak's persisted data directory
 (`~/.var/app/io.github.hikaps.couchplay/data/couchplay`), visible on your host at the
 same path; the second command installs it system-wide from there.
 
-**Standalone (curl one-liner):**
-```bash
-curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash
-```
-Beta (from `develop`):
-```bash
-curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --beta
-```
-> Requires Linux x86_64 and sudo. Beta builds include unreleased features and may be unstable.
-> `install.sh` also installs a native `couchplay` GUI binary and desktop entry. The
-> helper works on every distro; the native GUI only runs on Fedora-family distros —
-> on Arch/SteamOS, keep using the Flatpak above for the GUI.
+**One-liner:** see **Quick install** at the top of this section - it installs the Flatpak GUI and the helper together.
 
 **Uninstall the helper:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Beta build (from `develop`):
 curl -fsSL https://raw.githubusercontent.com/hikaps/couchplay/main/scripts/install.sh | bash -s -- --beta
 ```
 
-> Requires Linux x86_64 and sudo. On SteamOS the installer deploys a system extension
-> instead of the Flatpak. Pass `--tarball` for the native GUI binary (Fedora-family only).
+> Requires Linux x86_64 and sudo. On SteamOS the installer also deploys a system extension
+> for the privileged helper. Pass `--tarball` for the native GUI binary (Fedora-family only).
 > Beta builds include unreleased features and may be unstable.
 
 ### 1. Install the Flatpak (GUI)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -685,6 +685,89 @@ install_tarball() {
     echo ""
 }
 
+install_flatpak() {
+    local BETA="$1"
+    local release_json="$2"
+    local tag_name="$3"
+
+    print_info "Installing via Flatpak (recommended - runs on every distro)..."
+
+    if ! command -v flatpak &>/dev/null; then
+        print_error "flatpak not found. Install it, then re-run:"
+        echo "  Fedora/RHEL:    sudo dnf install flatpak"
+        echo "  Arch/CachyOS:   sudo pacman -S flatpak"
+        echo "  Debian/Ubuntu:  sudo apt install flatpak"
+        echo "  Or install the native build instead: re-run with --tarball"
+        exit 1
+    fi
+
+    local flatpak_url flatpak_sha_url
+    flatpak_url=$(get_asset_url "$release_json" "couchplay\.flatpak")
+    flatpak_sha_url=$(get_asset_url "$release_json" "couchplay\.flatpak\.sha256")
+    if [[ -z "$flatpak_url" ]]; then
+        print_error "Could not find couchplay.flatpak asset in release $tag_name"
+        exit 1
+    fi
+
+    TEMP_DIR=$(mktemp -d)
+    trap cleanup EXIT
+
+    local flatpak_file="${TEMP_DIR}/couchplay.flatpak"
+
+    print_info "Flatpak bundle: $flatpak_url"
+    if ! download_file "$flatpak_url" "$flatpak_file"; then
+        exit 1
+    fi
+
+    # Verify checksum when the release ships one.
+    if [[ -n "$flatpak_sha_url" ]]; then
+        local sha_file="${TEMP_DIR}/couchplay.flatpak.sha256"
+        if download_file "$flatpak_sha_url" "$sha_file"; then
+            verify_checksum "$flatpak_file" "$sha_file"
+        fi
+    fi
+
+    # Flatpak runs as the invoking user (never root); --user scopes installs to REAL_USER.
+    print_info "Ensuring Flathub remote + org.kde.Platform 6.10 runtime..."
+    sudo -u "$REAL_USER" flatpak remote-add --user --if-not-exists flathub \
+        https://flathub.org/repo/flathub.flatpakrepo || true
+    sudo -u "$REAL_USER" flatpak install --user --noninteractive -y \
+        flathub org.kde.Platform/x86_64/6.10
+
+    print_info "Installing CouchPlay Flatpak bundle..."
+    sudo -u "$REAL_USER" flatpak install --user --noninteractive -y "$flatpak_file"
+
+    # Export the privileged helper from the Flatpak, then install it system-wide.
+    print_info "Exporting privileged helper from the Flatpak..."
+    local fp_data="$REAL_HOME/.var/app/io.github.hikaps.couchplay/data/couchplay"
+    local real_uid
+    real_uid=$(id -u "$REAL_USER")
+    sudo -u "$REAL_USER" env "XDG_RUNTIME_DIR=/run/user/$real_uid" \
+        flatpak run --command=bash io.github.hikaps.couchplay \
+        -c "/app/share/couchplay/install-helper.sh export"
+    if [[ ! -f "$fp_data/install-helper.sh" ]]; then
+        print_error "Helper export failed: $fp_data/install-helper.sh not found"
+        echo "Retry manually:"
+        echo "  flatpak run --command=bash io.github.hikaps.couchplay -c '/app/share/couchplay/install-helper.sh export'"
+        echo "  sudo $fp_data/install-helper.sh install"
+        exit 1
+    fi
+
+    print_info "Installing privileged helper..."
+    "$fp_data/install-helper.sh" install
+
+    echo ""
+    print_info "=========================================="
+    print_info "CouchPlay $tag_name installed successfully!"
+    print_info "=========================================="
+    echo ""
+    echo "Launch CouchPlay from your application menu, or run:"
+    echo "  flatpak run io.github.hikaps.couchplay"
+    echo ""
+    echo "Prefer the native binary (Fedora-family only)? Re-run with --tarball."
+    echo ""
+}
+
 # =============================================================================
 # Main
 # =============================================================================
@@ -693,12 +776,14 @@ main() {
     local BETA=false
     local FORCE_SYSEXT=false
     local FORCE_TARBALL=false
+    local FORCE_FLATPAK=false
     
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --beta) BETA=true; shift ;;
             --sysext) FORCE_SYSEXT=true; shift ;;
             --tarball) FORCE_TARBALL=true; shift ;;
+            --flatpak) FORCE_FLATPAK=true; shift ;;
             *) shift ;;
         esac
     done
@@ -726,23 +811,15 @@ main() {
     tag_name=$(get_release_tag "$release_json")
     print_info "Latest release: $tag_name"
     
-    # Determine installation pathway
-    local USE_SYSEXT=false
+    # SteamOS uses a sysext; every other distro defaults to the Flatpak. --tarball forces native.
     if $FORCE_SYSEXT; then
-        USE_SYSEXT=true
-    elif $FORCE_TARBALL; then
-        USE_SYSEXT=false
-    else
-        # Auto-detect SteamOS
-        if [[ -f /etc/os-release ]] && grep -q "ID=steamos" /etc/os-release; then
-            USE_SYSEXT=true
-        fi
-    fi
-    
-    if $USE_SYSEXT; then
         install_sysext "$BETA" "$release_json" "$tag_name"
-    else
+    elif $FORCE_TARBALL; then
         install_tarball "$BETA" "$release_json" "$tag_name"
+    elif $FORCE_FLATPAK || ! { [[ -f /etc/os-release ]] && grep -q "ID=steamos" /etc/os-release; }; then
+        install_flatpak "$BETA" "$release_json" "$tag_name"
+    else
+        install_sysext "$BETA" "$release_json" "$tag_name"
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -722,9 +722,11 @@ install_flatpak() {
     # Verify checksum when the release ships one.
     if [[ -n "$flatpak_sha_url" ]]; then
         local sha_file="${TEMP_DIR}/couchplay.flatpak.sha256"
-        if download_file "$flatpak_sha_url" "$sha_file"; then
-            verify_checksum "$flatpak_file" "$sha_file"
+        if ! download_file "$flatpak_sha_url" "$sha_file"; then
+            print_error "Could not download checksum. Refusing to install without checksum verification"
+            exit 1
         fi
+        verify_checksum "$flatpak_file" "$sha_file"
     fi
 
     # Flatpak runs as the invoking user (never root); --user scopes installs to REAL_USER.


### PR DESCRIPTION
## Problem

We agreed **Flatpak is the default GUI** (it runs on every distro; the native binary fails on Arch/SteamOS via copy-relocation). But the one-liner (`install.sh`) contradicted this: on every **non-SteamOS** distro it ran `install_tarball()`, installing the **native** `couchplay` binary + helper. Only the SteamOS (`install_sysext`) path actually installed the Flatpak.

So a user running the documented one-liner on Arch/Fedora/Bazzite got the native binary — the exact thing that breaks on Arch/SteamOS.

## Change

- **New `install_flatpak()` pathway is the default** for all non-SteamOS distros:
  1. Download + checksum-verify `couchplay.flatpak`.
  2. Ensure the Flathub remote + `org.kde.Platform 6.10` runtime.
  3. `flatpak install --user` the bundle as the invoking user (Flatpak never runs as root; everything user-scoped goes through `sudo -u "$REAL_USER"`).
  4. Export the privileged helper from the Flatpak (`flatpak run … install-helper.sh export`) and install it system-wide — the same path documented in the README, which `install-helper.sh` already detects (flatpak-export layout, line 89-92).
- **`main()` pathway selection**: SteamOS → sysext; `--tarball` → native (Fedora-family opt-in); **default → flatpak**. New `--flatpak` flag to force it.
- **`flatpak.yml`**: generate + publish `couchplay.flatpak.sha256` (beta **and** stable releases) so the one-liner can verify the bundle — previously only the tarball/sysext had checksums. Old releases without the sha are handled gracefully (verification skipped).
- **README**: surface the one-liner as **Quick install** (Flatpak GUI + helper in one command); the manual flatpak/helper steps remain below it.

## Verification

- `bash -n scripts/install.sh` clean; `shellcheck` reports **zero** new findings (only the pre-existing `binary_name` SC2034).
- `flatpak.yml` parses as valid YAML.
- Confirmed `install-helper.sh` detects the flatpak-export layout (`$SCRIPT_DIR/couchplay-helper` + `$data/`), so the export→install step resolves correctly.
- Stable releases already ship `couchplay.flatpak` (via `flatpak.yml`'s `v*` tag trigger); this PR only adds the checksum.

## Notes

- No C++ changes; the unit suite is unaffected.
- The stable `main` one-liner stays on the old installer until the next release cut; this lands on `develop` (beta) first, as expected.
- End-to-end flatpak install can't be exercised in CI (needs a real runtime download + bwrap); validated by syntax/lint + structural review following the documented README path.
